### PR TITLE
Add publications and page numbers

### DIFF
--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="eaaf-1e11-a32d-ab11" name="Beastmen Brayherds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="4" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="eaaf-1e11-a32d-ab11" name="Beastmen Brayherds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="4" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Blood Rage" hidden="false" id="8117-de6e-d7df-3eca" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>

--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="eaaf-1e11-a32d-ab11" name="Beastmen Brayherds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="4" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
-    <profile name="Blood Rage" hidden="false" id="8117-de6e-d7df-3eca" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blood Rage" hidden="false" id="8117-de6e-d7df-3eca" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If when testing to see if it becomes subject to Primal Fury, this unit passes its Leadership test with any roll of a natural double, it will also become Frenzied in this wayeven if it has lost Frenzied earlier in the game.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Braystaff" hidden="false" id="583e-832e-5e02-23cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Braystaff" hidden="false" id="583e-832e-5e02-23cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model´s combat is choosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must choose to use its Braystaff offensively or defensively. Used offensively, a Braystaff count as a great weapon. Used defensively, a Braystaff count as a hand weapon as gains its wieder an Armour Value of 5+.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Brayhorn" hidden="false" id="5706-b80f-ecc9-85ee" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Brayhorn" hidden="false" id="5706-b80f-ecc9-85ee" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="92" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">From the beginning of round 2 onwards, if you General is on the battlefield during the Command sub phase of their turn, they may attempt to sound the Brayhorn by making a Leadership test. If this test is passed, you may immediately roll again for each unit of Ambushers in the army that is hold in reserve and that did not arrive during the Start od Turn sub-phase of this turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bull-gors" hidden="false" id="d485-902a-f6aa-8fbe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Bull-gors" hidden="false" id="d485-902a-f6aa-8fbe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact hits caused by a model with this special rule have an Armour Piercing characteristic of -1</characteristic>
       </characteristics>
     </profile>
-    <profile name="Primal Fury" hidden="false" id="24a7-8ec2-fca1-21e2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Primal Fury" hidden="false" id="24a7-8ec2-fca1-21e2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit´s comabt is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is passed, the unit becomes &quot;Primal Fury&quot; until the end of the Combat phase. A unit Primal Fury may re-roll any rolls To Hit of a natural 1.</characteristic>
       </characteristics>
@@ -31,7 +31,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by a model with this special rule has the Magical Attacks special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Drunken" hidden="false" id="7c-7525-760e-17ad" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Drunken" hidden="false" id="7c-7525-760e-17ad" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, roll on the Drunken table for each unit with this special rule that is not currently Frenzied, that is not engaged in combat and that is not fleeing.
 
@@ -46,7 +46,7 @@ D6
 6 - Belligerent Drunks: The unit has turned quite belligerent. Until the next Start of Turn sub-phase, the unit is subject to the Frenzy special rule. A unit whit this special rule may become Frenzied in this way even if it has lost Frenzy earlier in the game.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bestial Charge" hidden="false" id="4203-7f82-8eaa-bfd3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Bestial Charge" hidden="false" id="4203-7f82-8eaa-bfd3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="97" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3 or more, a model with this special rule gain a +1 modifier to its Strengh characteristic.</characteristic>
       </characteristics>
@@ -56,7 +56,7 @@ D6
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilist subject to Primal Fury, a hand weapon carried by a model with this special rule has an Armour Piercing characteristic of -2.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Swallow Whole" hidden="false" id="31dc-5b36-bbf8-bba3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Swallow Whole" hidden="false" id="31dc-5b36-bbf8-bba3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="110" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, a Ghorgon that is engaged in combat with one or more units of &quot;regular infantry&quot; or &quot;heavy infantry&quot; may choose to make &quot;Swallow Whole&quot; attack. To make Swallow Whole attack, nominate an enemy unit of regular or heavy infantry that the Ghorgon is engaged im combat with. The unit inmediately make an Initiative test.
 - If this test is failed, the Ghorgon grabs a victim from the unit and stuffs them into its gullet. A single model belonging to the target unit is inmediatly removed from play as casualty.
@@ -69,12 +69,12 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilist this model is Frenzied, any unit it has joined will also become Frenzied.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Maddening Aura" hidden="false" id="dfb4-a590-c057-c4f1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Maddening Aura" hidden="false" id="dfb4-a590-c057-c4f1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, any enemy unit that is withing 8&quot; of this model, including units that are fleeing or that are engaged in combat, must take a Leadership test. If this test is failed, the unit suffers D3 Strenght 3 Hits with no armour or Regeneration saves permited (Ward saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spurting Bile Blood" hidden="false" id="2e29-8f80-1a23-dbdb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spurting Bile Blood" hidden="false" id="2e29-8f80-1a23-dbdb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">For each Wound this model loses during the Combat phase, the attacking enemy unit suffer a Strength 4 hit with an AP of -1.</characteristic>
       </characteristics>
@@ -89,7 +89,7 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, S5, AP -1, Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Stony Stare" hidden="false" id="c32f-e4ed-cc42-69fc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Stony Stare" hidden="false" id="c32f-e4ed-cc42-69fc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="106" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">At the start of each Combat phase, enemy models in base contact with this model must make an Initiative test. If this test is failed, the suffer D3 Strength 2 hits, with no armour save permitted (Ward and Regeneration saves can be attempted as normal)</characteristic>
       </characteristics>
@@ -104,12 +104,12 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3, AP -1, Breath Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ghostsight" hidden="false" id="5b02-b6ce-8f7f-b393" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ghostsight" hidden="false" id="5b02-b6ce-8f7f-b393" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a Cygor may re-roll any failed roll To Hit made against enemy Wizards, enemy models or units equipped with any magic items, or enemy models or units with Ward or Regeneration save.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Soul-eater" hidden="false" id="b06f-c50f-6546-509c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Soul-eater" hidden="false" id="b06f-c50f-6546-509c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy Wizzard that wishes to start a spell whilist or withing 12&quot; of one or more Cygor unit, first make a Leadership test. If this test is failed, the Wizzard has lost their nerve and, should they fail to cast the spell, the spell has been misscast and the active player inmediatly roll on the Misscast table to see what fate bafalls the unfortunate Wizzard. If this test is passed, the Wizzard can continue with their casting attempt as normal.</characteristic>
       </characteristics>
@@ -504,17 +504,17 @@ Effect: If this Bound spell is cast, all unit whithing 6&quot; of this model (fr
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with the Mark of Chaos Undivided can re-roll any failed Fear, Panic or Terror tests.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blood Greed" hidden="false" id="5e04-be01-6254-98b9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blood Greed" hidden="false" id="5e04-be01-6254-98b9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilist Frenzied, this model has a +2 modifier to its Attacks characteristic (rather that the usual +1) However, such is this model´s desperate need to feed upon flesh that it rolls only a single D6 when making a Pursuit roll (rather than the usual 2D6)</characteristic>
       </characteristics>
     </profile>
-    <profile name="The Quickening Storm" hidden="false" id="74d8-efb5-1253-cb99" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="The Quickening Storm" hidden="false" id="74d8-efb5-1253-cb99" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wound suffered that were made by a Magic Misile or a Magical Vortex spell. In addition, if a  model with this special rule, or the unit it belongs to suffer one or more hits from Storm Call, it become Quickening. A Quickening model has a +1 modifier to both its Leadeship and Attacks characteristic. This Quickening last until your next Start of Turn sub-phase.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Razor Tusks" hidden="false" id="3650-49a2-85b-702e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Razor Tusks" hidden="false" id="3650-49a2-85b-702e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, the Armour Penetration characteristic of a Tuskgor or Razorgor tusk (hand weapon) is improved by 1.</characteristic>
       </characteristics>

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -45,7 +45,7 @@
 Note that a Field Trebuchet can still pivot freely at any time during its turn, and may make a follow up move as normal.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Finest Warhorses" hidden="false" id="abb5-9813-5e95-1d94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Finest Warhorses" hidden="false" id="abb5-9813-5e95-1d94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this special rule makes a Charge, Flee or Pursuit roll, it may re-roll any dice that roll a natural 1, before discarding any dice that are required to be discarded.</characteristic>
       </characteristics>
@@ -107,12 +107,12 @@ Note that a Field Trebuchet can still pivot freely at any time during its turn, 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models must make a Leadership test before making any rolls To Hit against the model during the Combat phase. If this test is failed, only rolls of a natural 6 will hit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Grail Monk" hidden="false" id="6143-47b6-82dd-978" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Grail Monk" hidden="false" id="6143-47b6-82dd-978" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="92" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Grail Monk is a command group model that follows all of the rules for a champion. In other words, a unit that contains both a Yeoman and a Grail Monk contains two champions.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blessed Triptych" hidden="false" id="dff9-cd97-d1c-ab35" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blessed Triptych" hidden="false" id="dff9-cd97-d1c-ab35" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="92" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit that contains a mode equipped with a Blessed Triptych gains the Stubborn special rule.</characteristic>
       </characteristics>
@@ -128,12 +128,12 @@ Double handed: S+1 AP1 Requires Two Hands</characteristic>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this characteristic has joined a unit that has a Unit Strength of 10 or more, and that has a Chivalrous Vow, they may voluntarily &apos;retire&apos; in the rear of the unit at any time, moving through the ranks and taking up a position away from the combat. Should they do so, they are no longer within the fighting rank and cannot make any attacks or have attacks directed against them. However, they continue to confer benefits to the unit in the form of Leadership and special rules, and they cast spells as if they were within the fighting rank.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Burning Braziers" hidden="false" id="3e5f-babb-4f9b-76c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Burning Braziers" hidden="false" id="3e5f-babb-4f9b-76c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">The longbows of a unit equipped with burning braziers gain the Flamming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Defensive Stakes" hidden="false" id="642d-3ed8-534e-3e52" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Defensive Stakes" hidden="false" id="642d-3ed8-534e-3e52" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit equipped with Defensive Stakes is deployed, the stakes are place in base contact with its front arc and will remain there for the duration of the game, unless the unit moves - should the unit move for any reason (including reforming), the stakes are lost and are removed from play. All measurements to and from the unit is done from the unit itself, ignore the stakes.
 
@@ -141,7 +141,7 @@ Double handed: S+1 AP1 Requires Two Hands</characteristic>
 Enemy units can charge the front of a unit equipped with Defensive Stakes as normal but do not have to physically  cross the stakes to do so. Instead, the front rank of a charging unit moves into base contact with the stakes, making a disordered charge and becoming Disrupted. A model whose troop type is &apos;cavalry&apos; or &apos;chariot&apos; must make a Dangerous Terrain test if it ends its charge move in base contact with the stakes.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Grail Reliquae" hidden="false" id="6e4e-5dbf-b254-52b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Grail Reliquae" hidden="false" id="6e4e-5dbf-b254-52b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="94" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">The Grail Reliquar is placed in the centre of the front tank of its unit (or as close to the centre as possible) and occupies the space of and counts as six models, tow in the first rank, two in the second and two in the third. If the unit turns or reforms, the Grail Reliquar must be repositioned into the new front rank.
 
@@ -157,12 +157,12 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include up to one Grail Reliquar for every character or unit with the Grail Vow it includes.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Living Saints" hidden="false" id="1113-147a-4ed6-67ce" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Living Saints" hidden="false" id="1113-147a-4ed6-67ce" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="97" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Every model in a unit of Grail Knights can issue and accept challenges in the same manner that a character.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dispersed Formation" hidden="false" id="2a78-f58a-ac7f-87ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dispersed Formation" hidden="false" id="2a78-f58a-ac7f-87ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="98" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">While in Skirmish formation, every model in a unit of Pegasus Knights must be within 2&quot; of another model belonging to the same unit, rather tan the usual 1&quot;.</characteristic>
       </characteristics>
@@ -432,7 +432,7 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="The Grail Vow" hidden="false" id="c4ac-f6a7-2481-db1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="The Grail Vow" hidden="false" id="c4ac-f6a7-2481-db1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="108" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
       </characteristics>
@@ -447,12 +447,12 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the &apos;Lore of the Lady&apos; special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead either the signature spell of their chosen Lore of Magic, or a spell from the &apos;Lore of the Lady&apos;.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Lance Formation" hidden="false" id="cc9a-f69f-d2e7-b352" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Lance Formation" hidden="false" id="cc9a-f69f-d2e7-b352" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Lance formation.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Peasantry" hidden="false" id="36a8-2e1e-31ba-afae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Peasantry" hidden="false" id="36a8-2e1e-31ba-afae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule is within 6&quot; of a friendly model that has the Knight&apos;s Vow, the Questing Vow or the Grail Vow, and if that model is not fleeing, this unit can use that model&apos;s Leadership characteristic instead of its own. In addition, a standard carried by a unit with this special rule cannot be counted as a trophy of war. A character with this special rule can only join a unit that also has this special rule.</characteristic>
       </characteristics>
@@ -470,7 +470,7 @@ Note that if there is no roll-off to determine which player takes the first turn
 Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can be list during a game. Any model or unit that flees, or any character that refuses a challenge, will immediately lose this special rule. For the purpose of this special rule, Falling Back in Good Order does not count as fleeing.</characteristic>
       </characteristics>
     </profile>
-    <profile name="The Questing Vow" hidden="false" id="1439-c8b1-9ff8-298a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="The Questing Vow" hidden="false" id="1439-c8b1-9ff8-298a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="108" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
       </characteristics>

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="f8cb-e518-1881-292" name="Bretonnians" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="1" revision="40" authorUrl="www.newrecruit.eu" authorContact="newrecruit.eu@gmail.com" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f8cb-e518-1881-292" name="Bretonnians" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="1" revision="40" authorUrl="www.newrecruit.eu" authorContact="newrecruit.eu@gmail.com" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile typeId="b070-143a-73f-2772" id="cd5f-980c-2da9-31b" name="Grail Knight" hidden="false" publicationId="3a81ff07--pubd1e638" typeName="Model">
       <characteristics>

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -3130,4 +3130,7 @@ Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can 
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
+  <publications>
+    <publication name="Arcane Journal - Kingdom of Bretonnia" hidden="false" id="5a09-81a4-8dd5-3c6e"/>
+  </publications>
 </catalogue>

--- a/Common Magic Items.cat
+++ b/Common Magic Items.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="6c22-b0e4-7c83-f9ce" name="Magic Items" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="2" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="6c22-b0e4-7c83-f9ce" name="Magic Items" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="2" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Magic Weapons" hidden="false" id="5b7a-30d2-42ea-4e29">
       <selectionEntries>

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="1ddf-26c6-1d88-2b8c" name="Dwarfen Mountain Holds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="8" revision="20" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="1ddf-26c6-1d88-2b8c" name="Dwarfen Mountain Holds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="8" revision="20" battleScribeVersion="2.03" type="catalogue" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedProfiles>
     <profile name="Longbeard" hidden="false" id="fbc8-de41-190b-8903" typeId="b070-143a-73f-2772" typeName="Model">
       <characteristics>

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -40,12 +40,12 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Resolute" hidden="false" id="a230-c540-6a65-4974" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Resolute" hidden="false" id="a230-c540-6a65-4974" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule suffer a -1 modifier to the result of any Flee roll or Pursuit roll they make (to a minimum of 1).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dwarf Crafted" hidden="false" id="b8b7-17f2-c5f-353d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dwarf Crafted" hidden="false" id="b8b7-17f2-c5f-353d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Model with this special rule do not suffer the usual -1 To Hit modifier when making a [Stand &amp; Shoot] charge reaction.</characteristic>
       </characteristics>
@@ -68,7 +68,7 @@
         <characteristic name="Description" typeId="adcd-c649-e6fc-a9f6">A model with this special rule may re-roll any roll of a natural 1 made when making an Armour Save roll</characteristic>
       </characteristics>
     </profile>
-    <profile name="Gromril Weapons" hidden="false" id="2e16-e293-353e-6881" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Gromril Weapons" hidden="false" id="2e16-e293-353e-6881" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by the model with this special rule has an Armour Piercing characteristic of -1.
 
@@ -88,13 +88,13 @@ Note that this special rule only applies to a single ordinary hand weapon. If th
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Deathblow" hidden="false" id="233a-1715-82be-1410" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Deathblow" hidden="false" id="233a-1715-82be-1410" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When a model with this special rule is reduced to zero Wounds by an enemy attack during the Combat phase, the unit that made the attack suffers a Strength 3 hit, with an AP of -1. 
 Note that if this model is reduced to zero Wounds whilst engaged in a challenge, it is the model that made the attack that suffers this hit rather than its unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Rune Lore" hidden="false" id="7bfd-8005-56c0-6e77" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Rune Lore" hidden="false" id="7bfd-8005-56c0-6e77" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may be nominated to attempt a Wizardly Dispel, as if it were a Wizard. For the purposes of Wizardly Dispel attempts:
 • An Anvil of Doom counts as level 3 Wizard.
@@ -115,7 +115,7 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Venerable" hidden="false" id="e78f-d6ed-5364-a697" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Venerable" hidden="false" id="e78f-d6ed-5364-a697" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="20" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6’’ of it can re-roll any failed Panic test.</characteristic>
       </characteristics>
@@ -133,12 +133,12 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Royal Guard" hidden="false" id="51a7-1a2-bff3-1d7a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Royal Guard" hidden="false" id="51a7-1a2-bff3-1d7a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="23" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include one unit of Hammerers for every King or Thane it includes. Any model in a unit of Hammerers that has been joined by a King or Thane can issue and accept challenges in the same manner as a character. Should the King or Thane leave the unit for any reason, the unit loses this ability.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Stoic Defenders" hidden="false" id="b2ce-d68c-502b-d777" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Stoic Defenders" hidden="false" id="b2ce-d68c-502b-d777" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="23" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it was charged by the enemy, a model with this special rule gains a +1 modifier to its Initiative and Attacks characteristics</characteristic>
       </characteristics>
@@ -214,7 +214,7 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+3 AP-3 Furious Charge, Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
-    <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness.</characteristic>
       </characteristics>
@@ -247,12 +247,12 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dive Bomb" hidden="false" id="37fa-95b7-5dec-19fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dive Bomb" hidden="false" id="37fa-95b7-5dec-19fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, a unit with this special rule may perform a &apos;Dive Bomb&apos; attack against a single enemy unit that is not engaged in combat. To do so, this unit must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this unit&apos;s movement is complete, the enemy unit suffers D6 Strength 3 hits, each with an AP of -1, for each model in this unit that moved over it. However, for each roll of a natural 1 made when determining the number of hits, a bob has misfired and this unit loses a single Wound instead.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bombing Run" hidden="false" id="e5db-41c3-532-871a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Bombing Run" hidden="false" id="e5db-41c3-532-871a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="29" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This model may perform a &apos;Bombing Run&apos; attack against a single enemy unit that is not engaged in combat. To do so, this model must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this model&apos;s movement is complete, roll on the Bombing Run table below:
 
@@ -484,12 +484,12 @@ Bombing Run Table:
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">10</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ancestral Grudge" hidden="false" id="c1e6-4b13-26b1-6f6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ancestral Grudge" hidden="false" id="c1e6-4b13-26b1-6f6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="12" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has the hatred Rule (enemy characters) special rule, meaning it hates all characters in the opponent army. If this character joins a unit of Longbeards or Hammerers, that unit will also gain this special rule. Should this character leave a unit of Longbeards or Hammerers they have joined for any reason, that unit loses this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Borne Aloft" hidden="false" id="93e6-c161-1b92-c8af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Borne Aloft" hidden="false" id="93e6-c161-1b92-c8af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="13" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with Shieldbearers consist of not one, but four models - the character and three loyal retainers - occupying a single base and acting together as a single entity. To represent this, a model with Shieldbearers has a split profile and follows the &apos;Split Profile (Cavalry)&apos; rule. In all other aspects this model is heavy infantry.</characteristic>
       </characteristics>
@@ -499,7 +499,7 @@ Bombing Run Table:
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Challenges issued by a character with an Oathstone cannot be refused. In addition, a character with an Oathstone and any unit they have joined automatically passes any Panic tests they are required to make, but cannot chose to Flee as a charge reaction.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ancestral Shield" hidden="false" id="fd89-f754-8e40-4a9f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ancestral Shield" hidden="false" id="fd89-f754-8e40-4a9f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="14" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">An Anvil of Doom and the Forgefather &amp; Anvil Guards have a 5+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
@@ -516,7 +516,7 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot be targeted by enemy shooting or by enemy spells whilst it is within 3&quot; of a friendly unit whose troop type is &apos;war machine&apos;.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Forgefire" hidden="false" id="8acf-1a19-b087-ef76" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Forgefire" hidden="false" id="8acf-1a19-b087-ef76" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="16" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character joins a unit that unit will game the Armour bane (2) and Flaming Attacks special rules. Should this character leave a unit it has joined for any reasons, that unit loses this special rule.</characteristic>
       </characteristics>
@@ -531,12 +531,12 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this character makes a roll To Wound, a roll of 4+ is always a success regardless of the target&apos;s Toughness. In addition, each unsaved wound inflicted by this character against an enemy model which troop type is &apos;behemoth&apos; has the Multiple Wounds(D3) special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Artillery Master" hidden="false" id="98bd-600b-cf60-ea7f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Artillery Master" hidden="false" id="98bd-600b-cf60-ea7f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="18" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this character is fleeing or engaged in combat, one per turn during the Shooting phase, a friendly unit of Quarrellers, unit of Thunderers or Dwarf war machine that is within its Command range can either re-roll any rolls To Hit of natural 1, or re-roll a single Artillery dice.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Entrenchment" hidden="false" id="e87a-e45b-4129-6ba6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Entrenchment" hidden="false" id="e87a-e45b-4129-6ba6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="18" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During deployment, you may &quot;Entrench&apos; a single non-character model whose troop type is &apos;war machine&apos; for each character in your army with this special rule. An Entrenched war machine is considered to be behind partial cover and to be defending a low linear obstacle. Should the war machine move for any reason, it is no longer Entrenched.</characteristic>
       </characteristics>

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -16,7 +16,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dragon Armour" hidden="false" id="f1fc-eaed-78ef-bc1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dragon Armour" hidden="false" id="f1fc-eaed-78ef-bc1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="184" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered. In addition a Wizard with this special rule may wear armour without penalty.</characteristic>
       </characteristics>
@@ -36,7 +36,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may re-roll any rolls of 1 when making Dangerous Terrain tests. In addition a Wizard with this special rule may wear armour without penalty.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ithilmar Weapons" hidden="false" id="ff10-6f2b-b0a4-9a1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ithilmar Weapons" hidden="false" id="ff10-6f2b-b0a4-9a1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When engaged in combat, a model with this special rule that in fighting with a hand weapon may re-roll any rolls To Hit of a natural 1.
 
@@ -48,7 +48,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike last</characteristic>
       </characteristics>
     </profile>
-    <profile name="Lion Cloak" hidden="false" id="4123-3227-347e-3b39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Lion Cloak" hidden="false" id="4123-3227-347e-3b39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule improves its armour value by 1 (to a maximum of 2+) against non-magical shooting attacks.</characteristic>
       </characteristics>
@@ -58,7 +58,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can make supporting attacks to its flank or rear as well as to its front.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blizzard Aura" hidden="false" id="d32a-1537-c2c9-1b1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blizzard Aura" hidden="false" id="d32a-1537-c2c9-1b1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst in base contact with this model, enemy models become subject to the Strike Last special rule.</characteristic>
       </characteristics>
@@ -129,7 +129,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Single use. During a Command sub-phase of their turn, this character may attempt to use the Horn of Isha by making a Leadershiop test (using their own Leadership). If the test is passed, until your next Start of Turn sub-phase, this character and any unit they have joined gain a +1 modifier to both their To Hit and their rolls To Wound.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Naval Discipline" hidden="false" id="ca28-8a3-989a-4ecc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Naval Discipline" hidden="false" id="ca28-8a3-989a-4ecc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="162" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit of Lothern Sea Guard may use this special rule when it makes a Stand &amp; Shoot charge reaction. A unit that does it can make a Stand &amp; Shoot charge reaction regardless of how close the charging unit is. Once this shooting has been resolved, the charged unit may make a free redraw the ranks manoeuvre, after which it will Hold until moved the charging unit.
 
@@ -137,7 +137,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
 Units that are fleeing, that are already engaged in combat when charged, or that has been joined by a character that dos not have this special rule, cannot use this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Chracian Warriors" hidden="false" id="2b64-4e75-6d83-19df" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Chracian Warriors" hidden="false" id="2b64-4e75-6d83-19df" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="163" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by your army&apos;s general or by a character with the Chracian Hunter Elven Honor.</characteristic>
       </characteristics>
@@ -152,7 +152,7 @@ Units that are fleeing, that are already engaged in combat when charged, or that
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a &apos;Cleaving Blow&apos;. Enemy models which troop type is &apos;regular infantry&apos; &apos;heavy infantry&apos;, &apos;regular cavalry&apos;, &apos;heavy cavalry&apos; or &apos;war beasts&apos; are not permitted an armour or Regeneration save against a Cleaving Blow (Ward saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Deflect Shots" hidden="false" id="42b9-dd12-7ae9-b1ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Deflect Shots" hidden="false" id="42b9-dd12-7ae9-b1ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="164" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered that were caused by a non magical shooting attack.</characteristic>
       </characteristics>

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="56fb-835b-a377-6639" name="High Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="15" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="56fb-835b-a377-6639" name="High Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="15" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Sons of Caledor" hidden="false" id="2f86-a9f-38aa-d39a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="10" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="10" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Orc Mobs" hidden="false" id="51e8-1471-ce4c-d5dd">
       <categoryLinks>

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -3642,7 +3642,7 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedProfiles>
-    <profile name="Choppas" hidden="false" id="b592-330-5a29-162f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Choppas" hidden="false" id="b592-330-5a29-162f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, a model with this special rule may re-roll any rolls To Wound on natural 1 and improves the Armour Piercing characteristic of its weapons by 1</characteristic>
       </characteristics>
@@ -3652,42 +3652,42 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When engaged in combat, a model with this special rule has a +1 modifier to its Strength characteristic and gains the Armour Base(1) special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Da Boyz" hidden="false" id="7a44-b74f-ad39-c2c8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Da Boyz" hidden="false" id="7a44-b74f-ad39-c2c8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army must include one Black Orc Boss for every Black Orc Mob it include and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fear of Elves" hidden="false" id="6cb0-9d5a-f165-e272" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fear of Elves" hidden="false" id="6cb0-9d5a-f165-e272" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Elves of any type cause Fear in modles with this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ignore Goblin Panic" hidden="false" id="78e4-fffe-6662-41fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ignore Goblin Panic" hidden="false" id="78e4-fffe-6662-41fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make Panic test when friendly Goblin unit is destroyed or Breaks and flee from combat while whithin 6&apos; of it. Nor does this unit have to make a Panic test when it is fled through by friendly Goblin unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ignore Panic" hidden="false" id="a097-2e5c-8366-efc1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ignore Panic" hidden="false" id="a097-2e5c-8366-efc1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make Panic test when friendly  unit that does not also have this special rule is destroyed or Breaks and flee from combat while whithin 6&apos; of it. Nor does this unit have to make a Panic test when it is fled through unit that does not have this special rule</characteristic>
       </characteristics>
     </profile>
-    <profile name="Quell Impetuosity" hidden="false" id="2fb3-330c-b6cb-fc2d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Quell Impetuosity" hidden="false" id="2fb3-330c-b6cb-fc2d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">While within 6&apos; of a unit with this special rule, friendly units may chose to ignore the Impetuous special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Tusker Charge" hidden="false" id="c392-507a-daf5-126" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Tusker Charge" hidden="false" id="c392-507a-daf5-126" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged a War Boar&apos;s Tusk (hand weapon) have a Strength characteristic of +1 and Armour Piercing characteristic of +1</characteristic>
       </characteristics>
     </profile>
-    <profile name="Waaagh!" hidden="false" id="7711-627f-5ae5-cc7c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Waaagh!" hidden="false" id="7711-627f-5ae5-cc7c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during the Comand sub-phase of their turn, this character may attempt to invoke the power of the Waaagh! by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase this character, their mount and any Orc unit they have joined mat re-roll ant rolls To Hit of natural 1 and when calculating its combat result, may claim an additional bonus of +1 combat result point.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warpaint" hidden="false" id="be75-116d-97e0-fbae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Warpaint" hidden="false" id="be75-116d-97e0-fbae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Warpaint gives its wearer 6+ Ward save against wounds suffered. However a model with this special rule can never war armour of any sort (though they may carry a shield).</characteristic>
       </characteristics>
@@ -3749,12 +3749,12 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">4</characteristic>
       </characteristics>
     </profile>
-    <profile name="Netters" hidden="false" id="fc41-af0f-b14a-8eb3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Netters" hidden="false" id="fc41-af0f-b14a-8eb3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="25" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit combat is chown. during Step 1.1 Chose &amp; Fight Combat sub-phase, it  may attempt to &apos;entangle&apos; one enemy unit it is engaged with. Roll a D6. On a roll of 1; that unit has entangled itself. On a roll of 2+, the enemy unit is entangled. Until the end of the Combat phase, an entangled unit suffers a -1 modifier to its Strength characteristic (to a minimuf of 1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Skulking Menace" hidden="false" id="8186-4d89-630-5b0a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Skulking Menace" hidden="false" id="8186-4d89-630-5b0a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="24" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Nasty Skulkers are not placed on the battlefield ath the start of the game. Instead, make a note of which Goblin Mobs include Nasty Skulkers, and of how many they include. These units are referred as &apos;concealing&apos; units. At the start if its first round of combat, during Step1.1 of the Choose Combat &amp; Fight sub-phase, a concealing unit must  must reveal its Nasty Skulkers - they cannot be revealed at any other time. Position each revealed Nasty Skulkers as you would a character that has joined the unit. Once placed, Nasty Skulker cannot leave their concealing unit. If a concealing unit is destroyed or flees the battlefield before its Nasty Skulkers are revealed, ther are removed as casualties.</characteristic>
       </characteristics>
@@ -3779,7 +3779,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When shootinh a Doom Driver catapul, follow the special</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bully" hidden="false" id="f03b-fc52-c489-f365" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Bully" hidden="false" id="f03b-fc52-c489-f365" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="41" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">An orc Bully is an special type of character that can b taken as an upgrade ...</characteristic>
       </characteristics>
@@ -4135,7 +4135,7 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">7</characteristic>
       </characteristics>
     </profile>
-    <profile name="Mob Rule" hidden="false" id="dbf3-b0e3-2fa7-b173" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Mob Rule" hidden="false" id="dbf3-b0e3-2fa7-b173" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="14" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character has joined a unit of Orcs with Unit Strength of 10 or more, they may apply a +1 modifier to any Casting roll they make. Should they leave the unit for any reason or should the Unit Strength fall below 10, this modifier is lost.</characteristic>
       </characteristics>

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="7b8f-602e-29cd-5786" name="The Empire of Man" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="7" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7b8f-602e-29cd-5786" name="The Empire of Man" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="7" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Prayers of Ulric" hidden="false" id="d1f4-5e82-b7ed-3ad0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -11,7 +11,7 @@
 - Wrath of Winter: Until your next Start of Turn sub-phase, this model, its mount and any unit it has joined gains the Multiple Wounds (2) special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Symbol of Might" hidden="false" id="5b74-eb4c-8bb7-3e7d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Symbol of Might" hidden="false" id="5b74-eb4c-8bb7-3e7d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">The Command range of a Lector of Sigmar mounted on the War Altar is increased from 8&quot; to 12&quot;
 
@@ -110,12 +110,12 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This character and any unit they have joined automatically ally passes any Panic test they are required to make.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fanatical Zeal" hidden="false" id="a6cf-dfbe-4dcb-153a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fanatical Zeal" hidden="false" id="a6cf-dfbe-4dcb-153a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="61" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be joined by a Lector of Sigmar or Priest of Sigmar. However, these are the only characters that can join the unit. A Lector of Sigmar or Priest of Sigmar that joins a unit of Flagellants is considered to have the Unbreakable special rule for as long as they remain with the unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Feel No Pain" hidden="false" id="854c-232c-4091-ac1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Feel No Pain" hidden="false" id="854c-232c-4091-ac1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="61" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has:
 - A 6+ Ward save against any wounds suffered that were caused by a non-magical enemy attack.
@@ -143,12 +143,12 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S8 AP-2 Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">All Wizards within this model&apos;s Command range (friend or foe) suffer a -2 modifier to their Casting rolls.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Grinding Wheels" hidden="false" id="77c2-c713-163c-883b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Grinding Wheels" hidden="false" id="77c2-c713-163c-883b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="68" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Stomp Attacks made by a Steam Tank have an Armour Piercing characteristic o -2. However, this special rule cannot be used against models whose troop type is &apos;behemoth&apos; - they are simply too large to be caught beneath a Steam Tank&apos;s wheels.
 
@@ -156,7 +156,7 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
 In addition, and unlike other chariots, this model treats low linear obstacles as open terrain rather than as impassable terrain.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Power" hidden="false" id="1a22-9799-5f09-36ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Steam Power" hidden="false" id="1a22-9799-5f09-36ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="68" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Steam Tank cannot march. Instead you may make a &apos;Steam Power&apos; roll and add the result to the model&apos;s Movement characteristic. To make a Steam Power roll, roll two D6 and discard the lowest result. The higher result is the result of the Steam Power roll. If both dice roll the same number, discard either.</characteristic>
       </characteristics>
@@ -178,12 +178,12 @@ However, if a natural 1 is rolled on both of the dice, the pressure is too great
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon. No armour saves is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Inner Circle" hidden="false" id="99b-d788-7989-4048" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Inner Circle" hidden="false" id="99b-d788-7989-4048" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="65" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When engaged in combat, a model with this special rule (but not its mount) may re-roll any rolls To Hit of a natural 1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Two Heads" hidden="false" id="d88f-d5c9-cec7-59e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Two Heads" hidden="false" id="d88f-d5c9-cec7-59e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="70" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">An Imperial Griffon with Two Heads gains a +1 modifier to its Attacks characteristic.</characteristic>
       </characteristics>
@@ -199,7 +199,7 @@ However, if a natural 1 is rolled on both of the dice, the pressure is too great
 After determining the number of shots, roll To hit for each as normal, using the crew&apos;s Ballistic Skill and applying all appropriate modifiers.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Holy Fervour" hidden="false" id="b1af-d24d-3cdc-e7d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Holy Fervour" hidden="false" id="b1af-d24d-3cdc-e7d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6&quot; of it automatically pass any Fear test they are required to make and can re-roll any failed Panic tests.</characteristic>
       </characteristics>

--- a/The Lores of Magic.cat
+++ b/The Lores of Magic.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="f3c5-af11-649d-5dbb" name="The Lores of Magic" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="10" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="f3c5-af11-649d-5dbb" name="The Lores of Magic" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="10" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedInfoGroups>
     <infoGroup name="Elementalism" hidden="false" id="b990-5f17-350f-c244">
       <profiles>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="9" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
-    <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Each time this model suffers an unsaved wound from a [Flaming Attack], your opponent may roll a D6. On a roll of 1-3, the flames quickly die down, and the model escapes further harm. On a roll of 4+, the flames take hold and this model loses one additional Wound. Note that excess wounds caused to a model will have no additional effect except in the case of a character that is part of a challenge, in which case this special rule counts for Overkill. Excess wounds do not ‘spill over’ onto other models in the unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Eternal Taskmaster" hidden="false" id="2cb-b6cc-72e8-ee9e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Eternal Taskmaster" hidden="false" id="2cb-b6cc-72e8-ee9e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="130" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to buff a unit they have joined to greater efforts by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase the character and any unit they have joined gains the Extra Attacks (+1) and Hatred (all enemies) special rules.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Indomitable (X)" hidden="false" id="9e4d-c79a-658d-6900" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Indomitable (X)" hidden="false" id="9e4d-c79a-658d-6900" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule reduces the number of wounds suffered due to the Unstable special rule by the number shown in brackets (shown here as ‘X’). Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest value for the entire unit. For example, if a character with Indomitable (2) joins a unit with Indomitable (1), the whole unit uses the character’s Indomitable (2) special rule</characteristic>
       </characteristics>
     </profile>
-    <profile name="Curse of the Necropolis" hidden="false" id="ccfe-3943-82d5-2a58" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Curse of the Necropolis" hidden="false" id="ccfe-3943-82d5-2a58" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule loses its last Wounds to an enemy attack, the unit that made the attack must immediately make a Leadership test. If this test is failed, the enemy unit suffers D3 Strength 2 hit, each with an AP of -.</characteristic>
       </characteristics>
@@ -26,7 +26,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ’Cleaving Blow’. Enemy models whose troops type is ’regular infantry’, ‘heavy infantry’, ‘light cavalry’ or ’heavy cavalry’ are not permitted an armour or [Regeneration] save against a Cleaving Blow (Ward saves can be attempted as normal). Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
-    <profile name="My Will Be Done" hidden="false" id="abde-68e9-9d0e-a46" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="My Will Be Done" hidden="false" id="abde-68e9-9d0e-a46" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="126" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to exert their will upon those around them by making a Leadership test (using their own Leadership). If the test is passed, choose one of the following modifiers. Until your next Start of Turn sub-phase this character, their mount and any unit they have joined gain that modifier (to a maximum of 10).
 - &quot;Forward to Glory!&quot;: +D3 Movement.
@@ -37,35 +37,35 @@
 Note that this special rule is not cumulative.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Arrows of Asaph" hidden="false" id="d57a-d79-ea09-8dbd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Arrows of Asaph" hidden="false" id="d57a-d79-ea09-8dbd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule never apply any modifiers to their rolls To Hit when shooting, regardless of the source of the modifiers.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Covenant of Power" hidden="false" id="e499-a9e5-3160-f62d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Covenant of Power" hidden="false" id="e499-a9e5-3160-f62d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="148" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst within 12&quot; of a Casket of Souls, friendly Liche Priests may apply a +1 modifier to any Casting roll they make. Additionally, any model (friendly or foe) that casts a Bound spell, whilst within 12&quot; of a Casket of Souls may apply a +1 modifier to the Casting roll.
 Note however that this bonus does not apply to any Bound Spells cast by the Casket of Souls.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Banner of the King" hidden="false" id="d88f-102f-fef9-dab2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Banner of the King" hidden="false" id="d88f-102f-fef9-dab2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Royal Herald that has been upgraded to be your Battle Standard Bearer replaces the &quot;Hold your Ground&quot; for:
 Friendly unit within the Battle Standard Bearer&apos;s Command range may re-roll any failed Leadership tests. In addition, friendly units within the Battle Standard Bearer Command range reduce the number of Wounds lost die to the Unstable special rule by D3.
 Note that this is not cumulative with the Indomitable (X) special rule. If a unit is affected by both, use the highest value.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Sworn Protector" hidden="false" id="26cd-4c1b-a55b-93a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Sworn Protector" hidden="false" id="26cd-4c1b-a55b-93a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Monarch of Nehekhara model suffer a hit whilst within 3&quot; of this model, you may choose to transfer that hit and all of its effect onto this model.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Arise!" hidden="false" id="a869-df99-ad99-f255" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Arise!" hidden="false" id="a869-df99-ad99-f255" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="128" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
       </characteristics>
     </profile>
-    <profile name="From Beneath the Sands" hidden="false" id="2363-698-c566-4bfb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="From Beneath the Sands" hidden="false" id="2363-698-c566-4bfb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="129" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
       </characteristics>
@@ -96,7 +96,7 @@ Note that this is not cumulative with the Indomitable (X) special rule. If a uni
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Nehekharan Undead" hidden="false" id="cc25-1643-8beb-8c64" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Nehekharan Undead" hidden="false" id="cc25-1643-8beb-8c64" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the [Fly (X)] special rule, and choose to move by flying). In addition, all Undead models have the following universal special rules:
 • [Fear]
@@ -171,7 +171,7 @@ A character with this special rule cannot join a unit without this special rule
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any unit that suffers one or more unsaved wounds from this weapon must make a Panic test as if it had taking heavy casualties.</characteristic>
       </characteristics>
     </profile>
-    <profile name="The Hierophant" hidden="false" id="c9c5-7aab-8e2e-2646" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="The Hierophant" hidden="false" id="c9c5-7aab-8e2e-2646" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="129" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Should this character be slain, the magical animus of the army starts to dissipate. As soon as this character is removed from play as a casualty, all friendly units with the Nehekharan Undead special Rule lose the Regeneration (X) special rule. In addition, at the end of the phase in which this model was removed from play as a casualty, and during each of your Start of Turn sub-phases for the remainder of the game, all friendly units with with the Nehekharan Undead special rule that are currently on the battlefield must make a Leadership test. If this test is failed, the unit loses a number of Wounds equal to the amount, by which it failed the test.</characteristic>
       </characteristics>
@@ -182,17 +182,17 @@ A character with this special rule cannot join a unit without this special rule
 Note that a Casket of Souls can still pivot freely at any time during its turn and may make follow up move as normal.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cloud of Dust" hidden="false" id="9ada-55bb-3fc4-e52b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Cloud of Dust" hidden="false" id="9ada-55bb-3fc4-e52b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="142" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy model that targets the model during the Shooting phase suffers an additional -1 To Hit modifier.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Unbound Spirits" hidden="false" id="54de-15ad-9dc8-e4be" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Unbound Spirits" hidden="false" id="54de-15ad-9dc8-e4be" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="149" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If the crew of a Casket of Souls is reduced to zero Wounds, immediately roll a D6 for every unit (friend or foe) within 12&quot; of the model. On a roll of 4+, the unit suffers D6 Strength 3 hits, with no armour or Regeneration saves permitted (Ward saves can be attempted as normal). Once these hits are resolved, the Casket of Souls is removed from play.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Khopesh" hidden="false" id="b049-caf4-f185-d3d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Khopesh" hidden="false" id="b049-caf4-f185-d3d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by a model with this special rule as an Armour Piercing characteristic of -1. Note that this special rule only applies to a single, ordinary hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapon or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
@@ -597,18 +597,18 @@ Note that a Casket of Souls can still pivot freely at any time during its turn a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the &apos;Lore of Nehekhara&apos; special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead either the signature spell of their chosen Lore of Magic, or a spell from the &apos;Lore of Nehekhara&apos;.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Vortex of Souls" hidden="false" id="a10c-954f-cdd4-5116" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Vortex of Souls" hidden="false" id="a10c-954f-cdd4-5116" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="149" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Casket of Souls can cast the following Bound spells, with a Power level of 3.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Unstoppable Assault" hidden="false" id="fbbb-aba9-7f94-97db" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Unstoppable Assault" hidden="false" id="fbbb-aba9-7f94-97db" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase of any turn in which this model charged, every attack it makes that causes an unsaved wound allows it to immediately make one additional attack. These additional attacks also benefit from this special rule.
 Note that any unsaved wound caused by the Stomp Attacks (D3) special rule do not benefit from this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Soul Reaper" hidden="false" id="31d6-475d-5db3-94b6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Soul Reaper" hidden="false" id="31d6-475d-5db3-94b6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment but before the first turn begins, nominate a single enemy character. This is the soul marked by the Necrosphinx to journey into the underworld by the battle&apos;s end. This model may re-roll any rolls To Hit of a natural 1 made against the nominated character.</characteristic>
       </characteristics>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="8" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="9" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedProfiles>
     <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
@@ -3189,4 +3189,7 @@ Note that any unsaved wound caused by the Stomp Attacks (D3) special rule do not
     <catalogueLink type="catalogue" name="Magic Items" id="739e-8a3d-bf64-d5b6" targetId="6c22-b0e4-7c83-f9ce"/>
     <catalogueLink type="catalogue" name="The Lores of Magic" id="69a3-f9a2-79d1-d6fd" targetId="f3c5-af11-649d-5dbb"/>
   </catalogueLinks>
+  <publications>
+    <publication name="Arcane Journal - Tomb Kings of Khemri" hidden="false" id="afac-86a8-e0f-2eef"/>
+  </publications>
 </catalogue>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="9" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="9" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="37" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<gameSystem id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="38" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <categoryEntries>
     <categoryEntry name="Characters" hidden="false" id="a4cc-15c9-cfae-1b3b"/>
     <categoryEntry id="f0e3-2e32-8866-ea32" name="Core"/>
@@ -1863,4 +1863,9 @@ Note that models in rear ranks use the line of sight of the model at the front o
       </modifiers>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
+  <publications>
+    <publication name="Core Rulebook" hidden="false" id="768b-3da1-a182-a1d8"/>
+    <publication name="Forces of Fantasy" hidden="false" id="8b8d-8fc4-559e-87b1"/>
+    <publication name="Ravening Hordes" hidden="false" id="7c89-736c-3139-24a0"/>
+  </publications>
 </gameSystem>

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="38" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="38" type="gameSystem" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <categoryEntries>
     <categoryEntry name="Characters" hidden="false" id="a4cc-15c9-cfae-1b3b"/>
     <categoryEntry id="f0e3-2e32-8866-ea32" name="Core"/>

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -198,7 +198,7 @@ Note that if a model uses a weapon that has the Requires To Hands special rule i
         <characteristic name="Description" typeId="adcd-c649-e6fc-a9f6">A model that rides a barded mount improves its armour value by 1. For example, a cavalry model equipped with heavy armour has a armour save of 5+. Should that model&apos;s mount be barded, its armour value would be improved by 1 by lowering the target number from 5+ to 4+.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Close Order" hidden="false" id="883e-e1b1-4fe9-5912" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Close Order" hidden="false" id="883e-e1b1-4fe9-5912" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Close Order formation.</characteristic>
       </characteristics>
@@ -233,7 +233,7 @@ Note that this special rule is not cumulative. If two or more models in a unit h
 In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Stubborn" hidden="false" id="e351-bbd6-f470-b604" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Stubborn" hidden="false" id="e351-bbd6-f470-b604" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">The first time the unit is required to make a break test it may choose no to and will automatically Fall Back in Good Order instead even if the Unit Strength of the winning side is more than twice that of the losing side. A unit that is not Stubborn does not become Stubborn when joined by a character that is. A Stubborn character cannot use this special rule whilst part of a unit that are not Stubborn.</characteristic>
       </characteristics>
@@ -243,7 +243,7 @@ In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
         <characteristic name="Description" typeId="adcd-c649-e6fc-a9f6">+3 Armour Save</characteristic>
       </characteristics>
     </profile>
-    <profile name="Shieldwall" hidden="false" id="32f7-8e30-3fe8-b11e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Shieldwall" hidden="false" id="32f7-8e30-3fe8-b11e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during a turn in which it was charged, a unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields,may Give Ground rather than Fall Back in Good Order.</characteristic>
       </characteristics>
@@ -253,58 +253,58 @@ In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane(1), Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Veteran" hidden="false" id="4022-c403-b083-ba83" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Veteran" hidden="false" id="4022-c403-b083-ba83" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the models in a unit have this special rule, the unit may re-roll any failed Leadership test.
 
 Note that a Break test is not a Leadership test.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Move Through Cover" hidden="false" id="e83e-f127-1904-3858" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Move Through Cover" hidden="false" id="e83e-f127-1904-3858" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not suffer any modifier to their Movement characteristic for moving through difficult or dangerous terrain. In addition, a model with this special rule may re-roll any rolls of 1 when making Dangerous Terrain tests.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Open Order" hidden="false" id="5b67-8535-146c-7cea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Open Order" hidden="false" id="5b67-8535-146c-7cea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt an Open Order formation.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Scouts" hidden="false" id="fe5e-8838-7fbd-a7ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Scouts" hidden="false" id="fe5e-8838-7fbd-a7ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may be deployed after all other units from both armies. They can be deployed anywhere on the battlefield that is more than 12&quot; away from an enemy model. If deployed in this way, Scouts cannot declare a charge during their first turn.
 
 If both armies contain Scouts, a roll-off should determine which player deploys Scouts first. The player then alternate deploying their scouting units one at a time, starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Skirmishers" hidden="false" id="59a5-7eca-ee35-96ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Skirmishers" hidden="false" id="59a5-7eca-ee35-96ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Skirmish formation.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Detachment" hidden="false" id="559-d4c6-b2e8-500f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Detachment" hidden="false" id="559-d4c6-b2e8-500f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be fielded as a detachment.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ambushers" hidden="false" id="8c0b-6fe6-dc06-512" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ambushers" hidden="false" id="8c0b-6fe6-dc06-512" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may be held on reserve rather than be deployed on the start of the game. From the beginning of round two onwards roll a D6 during each of your Start of Turn sub phases for each unit of Ambushers in your army that is held on reserve. On a roll of 1-3 the unit is delayed until your next turn at least. On a roll of 4+, the unit arrives entering the battlefield as reinforcements during the Compulsory Moves sub-phase. The unit may be placed on any edge of the battlefield chosen by its controlling player, but cannot be placed within 8&quot; of an enemy model. If any Ambushers are still held on reserve by the start of round five, they arrive automatically.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Vanguard" hidden="false" id="691e-10ec-4f7c-a2c4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Vanguard" hidden="false" id="691e-10ec-4f7c-a2c4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment units with this special rule may make a Vanguard move. A unit making a Vanguard move moves as described on the Basic Movement rules. It may manoeuvre normally but cannot march.
 
 If both armies contain Vanguard units a roll off determines who moves first. The players then alternate moving their Vanguard units one at a time starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warband" hidden="false" id="505f-e12d-2e36-31d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Warband" hidden="false" id="505f-e12d-2e36-31d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Warband gains .????</characteristic>
       </characteristics>
     </profile>
-    <profile name="Impetuous" hidden="false" id="b664-8530-a988-7ba9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Impetuous" hidden="false" id="b664-8530-a988-7ba9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If during the Declare Charge &amp; Charge Reaction sub-phase of its turn, a unit that includes one or more Impetuous models is able to declare charge, roll a D6. On a roll of 1-3, the unit must declare a charge. On a roll of 4+, the unit may act as normal.</characteristic>
       </characteristics>
@@ -334,7 +334,7 @@ If both armies contain Vanguard units a roll off determines who moves first. The
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. Models whose troop type is &apos;infantry&apos; only. A model wielding a thrusting spear cannot m ake a supporting attack during a turn in which it charged. During a turn it was charged in its front arc, a model wielding a thrusting spear gains +1 modifier to its Initiative against the charging unit(s)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Frenzied model has a +1 modifier to its Attacks characteristic. This modifier does not apply to the model&apos;s mount (i.e. the mount of a cavalry model), to the beasts that drag it (in the case of a chariot), or to its rider (in the case of a monster).
 In addition:
@@ -359,14 +359,14 @@ For example, if a natural 6 is rolled when rolling To Wound with a weapon that h
 Note that a model that wears no armour is considerer to have an armour value of 7+ for the purposes of rules that improve armour value.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Breath Weapon" hidden="false" id="e049-8b4d-23e9-7505" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Breath Weapon" hidden="false" id="e049-8b4d-23e9-7505" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with a Breath Weapon can use it once per round, during the Shooting phase of its turn. Place the flame template, with its broad end over the intended target and its narrow end touching the model&apos;s base edge anywhere along its front arc. The template must lie entirely within the model&apos;s vision arc. Any model whose base lies underneath the template risks being hit. The Strength and any special rules of the breath weapon will be detailed in the creature&apos;s rules.
 
 Breath weapons cannot be used when making a [Stand &amp; Shoot] charge reaction, or when the model is engaged in combat.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Counter Charge" hidden="false" id="5186-798d-69d-6545" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Counter Charge" hidden="false" id="5186-798d-69d-6545" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This special rule can only be used by units that consists entirely of models with this special rule. When a unit with this special rule is charged in its front arc by an enemy unit whose troop type is &apos;cavalry&apos;, &apos;chariot&apos; or &apos;monster&apos;, it may declare a &apos;Counter Charge&apos; charge reaction.
 
@@ -377,29 +377,29 @@ Otherwise, pivot the unit about its center so that it is facing directly towards
 Fleeing units and units already engaged in combat when charged cannot Counter Charge. A unit can only Counter Charge in response to one charge per turn, even if charged by multiple units. Once all charges have been declared, the inactive player can choose which charging unit to Counter Charge. The unit will then Hold against the other charging units.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cumbersome" hidden="false" id="9db1-2d1d-b6dd-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Cumbersome" hidden="false" id="9db1-2d1d-b6dd-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Weapons with this special rule cannot be used when making a Stand &amp; Shoot charge reaction.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dragged Along" hidden="false" id="a042-c2f5-ebcb-2bab" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dragged Along" hidden="false" id="a042-c2f5-ebcb-2bab" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule that begins its movement within 1&quot; of a friendly unit whose troop type is &apos;infantry&apos; that is not fleeing and that contains ten or more models may replace its Movement characteristic with that of the unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Drilled" hidden="false" id="1f64-3ddc-db58-12fb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Drilled" hidden="false" id="1f64-3ddc-db58-12fb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Drilled unit may perform a free redress the ranks manoeuvre immediately before moving. Once this manoeuvre is complete, the unit moves as normal. In addition a Drilled unit can march whilst within 8&quot; of an enemy unit without first having to make a Leadership test.
 
 Note that any character that joins a Drilled unit is considered to be Drilled as well.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ethereal" hidden="false" id="6561-8029-dac3-162" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ethereal" hidden="false" id="6561-8029-dac3-162" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Ethereal creatures treat all terrain as open ground for the purpose of movement. They cannot end their movement inside impassible terrain, though they can pass through it. In addition, Ethereal creatures can only be wounded by Magical attacks. Characters that are not Ethereal cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Evasive" hidden="false" id="9fff-999f-6e96-e149" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Evasive" hidden="false" id="9fff-999f-6e96-e149" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, when the unit is declared the target during the enemy Shooting phase, it may choose to Fall Back in Good Order and will flee directly away form the enemy unit shooting at it. Once this unit has completed its move, the enemy unit may continue with its shooting as declared.</characteristic>
       </characteristics>
@@ -409,12 +409,12 @@ Note that any character that joins a Drilled unit is considered to be Drilled as
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a modifier to its Attacks characteristic, as shown in the brackets after the name of this special rule (+X). If this modifier is determined by the roll of a dice, roll when the model&apos;s combat is chosen during any Choose &amp; Fight sub phase.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fast Cavalry" hidden="false" id="df-a39-e62-1c57" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fast Cavalry" hidden="false" id="df-a39-e62-1c57" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If all of the models (including Characters) within a unit arrayed in an Open Order formation have this special rule, the unit may perform its Quick Turn even if marched.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fear" hidden="false" id="5ec9-a98-d8c5-e18b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fear" hidden="false" id="5ec9-a98-d8c5-e18b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot flee.
 
@@ -425,17 +425,17 @@ If a unit is engaged with an enemy unit that both causes Fear and has a higher U
 A unit only needs to make one Fear test per turn. Models that cause Fear are immune to Fear. A unit that does not cause Fear does not become immune to Fear when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Feigned Flight" hidden="false" id="eea7-89d9-a996-403c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Feigned Flight" hidden="false" id="eea7-89d9-a996-403c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit chooses to Flee (or Fire &amp; Flee) as a charge reaction, it automatically rallies at the end of its move.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fight In Extra Rank" hidden="false" id="b49e-b47f-fb38-596e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fight In Extra Rank" hidden="false" id="b49e-b47f-fb38-596e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may make a supporting attack.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fire &amp; Flee" hidden="false" id="1a06-31aa-cbfe-1a5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Fire &amp; Flee" hidden="false" id="1a06-31aa-cbfe-1a5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is also armed with missile weapons may declare that it will &apos;Fire &amp; Flee&apos; as a charge reaction.
 
@@ -444,19 +444,19 @@ Fire and Flee: The unit launches a volley of weapons fire before turning to flee
 Note that, if the distance between this unit and the charging unit is less than the Movement characteristic of the charging unit, this unit must either Hold or Flee.</characteristic>
       </characteristics>
     </profile>
-    <profile name="First Charge" hidden="false" id="785a-2886-af42-dce9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="First Charge" hidden="false" id="785a-2886-af42-dce9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit&apos;s first charge of the game is successful (i.e. if the unit makes contact with the charge target), the charge target becomes Disrupted unit the end of the Combat phase of that turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flaming Attacks" hidden="false" id="e45d-952-f679-ae2c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Flaming Attacks" hidden="false" id="e45d-952-f679-ae2c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made of hits caused by a model with this special rule or made using a weapon or spell with this special rule, is a &quot;Flaming&quot; attack. In addition, a model with this special rule causes Fear to models which troop type is &apos;war beasts&apos; or &apos;swarms&apos;.
 
 Unless otherwise stated, a model with this special rule makes Flaming attacks both when shooting and in combat (though any spells cast by the model are unaffected, as are any attacks made with magic weapons they might be weilding).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flammable" hidden="false" id="8f64-6d4c-466b-1b94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Flammable" hidden="false" id="8f64-6d4c-466b-1b94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Flaming attack.</characteristic>
       </characteristics>
@@ -472,17 +472,17 @@ Unless otherwise stated, a model with this special rule makes Flaming attacks bo
 Models that can Fly must begin and end all their movement on the ground. A character with this special rule cannot join a unit without this special rule, and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Furious Charge" hidden="false" id="eaca-69a2-8b6a-81c6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Furious Charge" hidden="false" id="eaca-69a2-8b6a-81c6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3&quot; or more, a model with this special rule gains a +1 modifier to its Attacks characteristic.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Horde" hidden="false" id="9cba-89a5-1796-5fe4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Horde" hidden="false" id="9cba-89a5-1796-5fe4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may increase the maximum Rank Bonus it can claim (as determined by its troop type) by one.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ignores Cover" hidden="false" id="a401-372d-446e-d27c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ignores Cover" hidden="false" id="a401-372d-446e-d27c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model making a shooting attack has this special rule, it ignores any To Hit modifiers caused by partial or full cover.</characteristic>
       </characteristics>
@@ -494,48 +494,48 @@ Models that can Fly must begin and end all their movement on the ground. A chara
 Note that this special rule does not make a unit immune to any test make against Leadership not stated here.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Killing Blow" hidden="false" id="860b-e13a-4710-9bf0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Killing Blow" hidden="false" id="860b-e13a-4710-9bf0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it ha struck a &apos;Killing Blow&apos;. Enemy models whose troop type is &apos;infantry&apos; or &apos;cavalry&apos; are not permitted an armour save or Regeneration save against a Killing Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is &apos;infantry&apos; or &apos;cavalry&apos; suffers an unsaved wound from Killing Blow, it looses all of its remaining Wounds.
 
 Note that if an attack wounds automatically this special rule cannot be used/</characteristic>
       </characteristics>
     </profile>
-    <profile name="Levies" hidden="false" id="8cc3-d6f5-da17-6600" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Levies" hidden="false" id="8cc3-d6f5-da17-6600" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot use Inspiring Presence rule of the army&apos;s general nor the Hold your Ground rule of a Battle Standard. However, little is expected from Levies in battle. Therefore units that do not have this special rule are not required to make a Panic test when a friendly unit of Levies Breaks and flees from combat.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Loner" hidden="false" id="2ecd-c6b3-bd8b-864b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Loner" hidden="false" id="2ecd-c6b3-bd8b-864b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot be your General and cannot join a unit without this special rule. A unit with this special rule cannot be joined by a character without this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Magical Attacks" hidden="false" id="2125-6aa2-f782-42bf" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Magical Attacks" hidden="false" id="2125-6aa2-f782-42bf" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hit caused by a mode with this special rule, or made using a weapon with this special rule, is a &apos;Magical&apos; attack.
 
 Note that all spells are considered to have this special rule, as are any hits caused by magic items.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Mercenaries" hidden="false" id="4d1b-2617-ebdc-4f4d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Mercenaries" hidden="false" id="4d1b-2617-ebdc-4f4d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Often, an army can include certain units drawn from another army list as mercenaries. Any such units included in your army gain this special rule. Mercenaries cannot use the Inspiring Presence rule of the army&apos;s general nor the Hold the Ground rule of a Battle Standard. Mercenaries cannot be joined by characters drawn form another army list.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Monster Handlers" hidden="false" id="1084-a4e9-79f-3462" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Monster Handlers" hidden="false" id="1084-a4e9-79f-3462" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A monster with this special rule is accompanied by one or more models representing its handlers. During deployment, position these models anywhere that is adjacent to, an in base contact with, the monster. If the handlers are found to be blocking movement or line of sight, simply move them aside.
 
 In combat, each handler adds its attacks to those of the monster. If the monster suffers an unsaved wound, roll a D6. On a roll of 1-4 the monster looses a Wound, but on a roll of 5+ a handler model suffers the wound instead. If the monster is removed from play, so are its handlers.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Chariot Runners" hidden="false" id="afa3-a46a-2608-f62c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Chariot Runners" hidden="false" id="afa3-a46a-2608-f62c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Friendly models whose troop type is &apos;chariot&apos; can draw a line of sight over or through models with this special rule and can move through friendly units of Chariot Runners that are in Skirmish formation. If the chariot&apos;s move would result in it ending up &apos;on top&apos; of a Chariot Runner, simple nudge the Chariot Runner aside by the smallest amount possible, to make space for the chariot. Whilst in Skirmish formation units of Chariot Runners can treat friendly chariots that are within 1&quot; of one or more of the unit&apos;s models as part of the unit for the purpose of unit coherency.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Howdah" hidden="false" id="b8f6-1cbc-b19-c7b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Howdah" hidden="false" id="b8f6-1cbc-b19-c7b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">To represent its howdah and crew, a behemoth with this special rule has a split profile and follows both the &apos;Split Profile (Chariots)&apos; and &apos;Firing Platform&apos; rules. In all other respects, this model is a behemoth.</characteristic>
       </characteristics>
@@ -547,19 +547,19 @@ In combat, each handler adds its attacks to those of the monster. If the monster
 Resolving Impact Hits: Impact Hits can only be made by a charging model that moved 3&quot; or more and that is in base contact with the enemy. Impact hits are attacks made in combat that always strike at Initiative 10 (regardless of modifiers), and that hit automatically using the unmodified Strength characteristic of the model.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Large Target" hidden="false" id="c822-7ad0-f24a-e4af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Large Target" hidden="false" id="c822-7ad0-f24a-e4af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models never suffer To Hit modifiers for full or partial cover when shooting at models with this special rule. In addition, a model can draw a line of sight to a model with this special rule over or though other models and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Monster Slayer" hidden="false" id="6b2f-7ce0-3e27-4ded" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Monster Slayer" hidden="false" id="6b2f-7ce0-3e27-4ded" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a &apos;Monster Slaying Blow&apos;. Enemy models whose troop type is &apos;monster&apos; are not permitted an armour or Regeneration save against a Monster Slaying Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is &apos;monster&apos; suffers an unsaved wound from a Monster Slaying Blow, it loses all of it remaining Wounds.
 
 Note that if an attack wounds automatically this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Motley Crew" hidden="false" id="6359-4018-5cd4-3720" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Motley Crew" hidden="false" id="6359-4018-5cd4-3720" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may include models of the same type that are equipped differently to one another, and/or models of different types that fight together in a single unit. If necessary, the army list entry for such units will be accompanied by a brief explanation of the unit&apos;s composition.
 
@@ -570,22 +570,22 @@ Different Armour: Models within a Motley Crew may have different armour values. 
 Casualty Removal: Against enemy shooting, casualty removal should be divided as equally as possible between the different models within the unit. In combat, casualties should be removed from among the majority of the models that make up the fighting rank. In either case, available models are brought forward from rear ranks to fill any gaps, as chosen by the controlling player.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Move &amp; Shoot" hidden="false" id="6d4e-d525-ad86-4e4a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Move &amp; Shoot" hidden="false" id="6d4e-d525-ad86-4e4a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule can be used in the Shooting phase even if the model equipped with it marched this turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Rallying Cry" hidden="false" id="23c4-bd19-2422-ad08" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Rallying Cry" hidden="false" id="23c4-bd19-2422-ad08" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the command sub-phase of their turn, if they are nor engaged in combat, this character may nominate a single fleeing friendly unit that is within their Command range. The nominated unit immediately makes a Rally test. If the test is failed the unit may attempt to rally again as normal during the Rally sub-phase</characteristic>
       </characteristics>
     </profile>
-    <profile name="Quick Shot" hidden="false" id="f733-b74b-6cb1-c69" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Quick Shot" hidden="false" id="f733-b74b-6cb1-c69" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule does not suffer the usual -1 To Hit modifier for Moving and Shooting. In addition, a unit equipped with weapons with this special rule can use them to make a Stand &amp; Shoot charge reaction regardless of how close the charging unit is.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ponderous" hidden="false" id="1170-9414-b4b5-a125" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ponderous" hidden="false" id="1170-9414-b4b5-a125" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule suffers a To Hit modifier of -2 for Moving and Shooting, rather than the usual -1.</characteristic>
       </characteristics>
@@ -607,19 +607,19 @@ Note that excess wounds caused to a model will have no additional effect unless 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule can either fire a single shot as normal, or it can be fired a number of times, as shown in brackets after the name of this special rule (X). If multiple shots are fired, each roll To Hit suffers an additional -1 To Hit modifier. All models in a unit equipped with weapons with this special rule must fire either a single or Multiple Shots. Where the number of Multiple Shots is generated by a dice roll, roll separately for each model.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Poisoned Attacks" hidden="false" id="81f5-4895-4abc-fc39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Poisoned Attacks" hidden="false" id="81f5-4895-4abc-fc39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with Poisoned Attacks rolls a natural 6 when making a roll To Hit, that hit will wound automatically. Unless otherwise stated, a model with this special rule may use it when making both shooting and combat attacks. Any spells cast by the model are unaffected, as are any attacks made with magic weapons.
 
 Note that if an attack needs a To Hit roll of 7+, or hits automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Random Attacks" hidden="false" id="1b08-4621-6379-ff1f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Random Attacks" hidden="false" id="1b08-4621-6379-ff1f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Attacks characteristic. Instead, a dice roll is given (D3+1, for example). Each time a model with this special rule attacks in combat, roll a dice to determine the number of attacks it will make, then roll To Hit as normal. If a fighting rank contains mode than one model with this special rule, roll separately for each, unless specified otherwise.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Random Movement" hidden="false" id="4924-fc1f-bcd-746a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Random Movement" hidden="false" id="4924-fc1f-bcd-746a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule move during the Compulsory Moves sub-phase. They cannot march or declare a charge. They can wheel to change direction, but cannot perform any other manoeuvres. If the model is able to make contact with an enemy unit during the Compulsory Moves sub-phase or whilst pursuing, it may do so and counts as having charged. The model aligns against the enemy unit and stops moving. A unit charged in this way must Hold.
 
@@ -633,17 +633,17 @@ If every model in a unit has this special rule, toll once for the entire unit. I
 Note that models with this special rule are often vulnerable to the Flaming Attacks or Magical Attacks special rules.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Regimental Unit" hidden="false" id="7424-ec43-7581-965a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Regimental Unit" hidden="false" id="7424-ec43-7581-965a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be accompanied by &apos;detachments&apos;.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Requires Two Hands" hidden="false" id="4f8d-35e-6be9-dabb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Requires Two Hands" hidden="false" id="4f8d-35e-6be9-dabb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model cannot use a shield alongside a weapon with this special rule during the Combat phase (a shield can still be used against wounds caused by shooting or magic during other phases of the game).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Reserve Move" hidden="false" id="1f10-d7d-be19-7e8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Reserve Move" hidden="false" id="1f10-d7d-be19-7e8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless is charged, marched or fled during the Movement phase of its turn, a unit with this special rule may make a Reserve move at the end of the Shooting phase of its turn, after all shooting has been resolved. A unit making a Reserve move moves as described in the Basic Movement rules. It may manoeuvre but cannot march.</characteristic>
       </characteristics>
@@ -655,17 +655,17 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
 Resolving Stomp Attacks: Stomp Attacks can only be made by a model that is in base contact with the enemy. Stomp Attacks are attacks made in combat that always strike at Initiative 1 (regardless of modifiers) and that hit automatically using the unmodified Strength characteristic of the model.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Strike First" hidden="false" id="48fd-23c1-c0d5-ae1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Strike First" hidden="false" id="48fd-23c1-c0d5-ae1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rile that is engaged in combat improves its Initiative characteristic to 10 (before any other modifiers are applied). If a model has both this rule and Strike Last, the two rules cancel each other out.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Strike Last" hidden="false" id="7c4d-72c1-eeb-ab5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Strike Last" hidden="false" id="7c4d-72c1-eeb-ab5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase a model with this special rule that is engaged in combat  reduces its Initiative characteristic to 1 (before any other modifiers are applied). If a model has both this rule and Strike First, the two rules cancel each other out.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Stupidity" hidden="false" id="f7af-e016-1f9c-54c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Stupidity" hidden="false" id="f7af-e016-1f9c-54c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is engaged in combat, a unit with this special rule must make a &apos;Stupidity&apos; test during the Start of Turn sub-phase of its turn. To make a Stupidity test, test against the unit&apos;s Leadership characteristic. If this test is failed the unit becomes Stupid. A Stupid unit:
 
@@ -676,12 +676,12 @@ Resolving Stomp Attacks: Stomp Attacks can only be made by a model that is in ba
 A unit or mount that does not have this special rule becomes subject to it when joined or ridden by a character that does (Stupidity is contagious).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Swiftstride" hidden="false" id="dc91-48b3-3696-217" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Swiftstride" hidden="false" id="dc91-48b3-3696-217" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">???</characteristic>
       </characteristics>
     </profile>
-    <profile name="Terror" hidden="false" id="c7a2-35bf-4313-f4f0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Terror" hidden="false" id="c7a2-35bf-4313-f4f0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Terror. Models that cause Terror also cause Fear.
 
@@ -693,29 +693,29 @@ Note that if a charged unit cannot choose to Flee, it does not make this Leaders
 Models with the Fear special rule Fear models that cause Terror. Models that cause Terror are immune to Terror. A unit that does not cause Terror does not become immune to Terror when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Timmm-berrr!" hidden="false" id="4f28-3f86-cf88-6b3a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Timmm-berrr!" hidden="false" id="4f28-3f86-cf88-6b3a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model is reduced to zero Wounds, the winner of a roll-off choses one of its arcs(front, flank or rear) for it to fall into. Army units that are within the chosen arc and in base contact with this model suffer D6 hits, each using the Strength characteristic of this model with an AP of -1. Once these hits are resolved, this model is removed from play.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Unbreakable" hidden="false" id="d3eb-1fa0-bb19-f390" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Unbreakable" hidden="false" id="d3eb-1fa0-bb19-f390" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rile loses a round of combat, it is not required to make a Break test. Instead, it will automatically Give Ground as it is pushed back by the enemy. Characters that are not Unbreakable cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warp-spawned" hidden="false" id="c24d-4386-c1ef-f195" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Warp-spawned" hidden="false" id="c24d-4386-c1ef-f195" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Magical attack. In addition, characters that are not Warp-spawned cannot join a unit that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Volley Fire" hidden="false" id="330c-821e-8fe0-d4ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Volley Fire" hidden="false" id="330c-821e-8fe0-d4ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this special rile makes a shooting attack, half of the models in each rank other than the front rank (or front two ranks if the unit is on a hill), rounding up, can shoot (in addition to the usual models that shoot from the front rank, or front two ranks if the unit is on a hill). A unit cannot Volley Fire if it has moved for any reason during this turn (including reforming), or when making a Stand &amp; Shoot charge reaction.
 
 Note that models in rear ranks use the line of sight of the model at the front of their file.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Unstable" hidden="false" id="a10e-13b7-e959-ab5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Unstable" hidden="false" id="a10e-13b7-e959-ab5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">??????</characteristic>
       </characteristics>
@@ -975,7 +975,7 @@ Note that models in rear ranks use the line of sight of the model at the front o
         <characteristic name="Description" typeId="9f84-4221-785a-db50">???</characteristic>
       </characteristics>
     </profile>
-    <profile name="Nehekharan Phalanx" hidden="false" id="a527-88cc-ddd6-1ea0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Nehekharan Phalanx" hidden="false" id="a527-88cc-ddd6-1ea0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may choose not to Give Ground Should it lose a round in combat. However, if the winning side significantly outnumbers the losing side, it will overwhelm the loser. If the Unit Strength of the winning side is more than twice that of the losing side, the unit cannot use this special rule and must Give Ground as normal.</characteristic>
       </characteristics>

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c908-5f26-5bdf-2a48" name="Warriors of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="14" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c908-5f26-5bdf-2a48" name="Warriors of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="14" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Chaos Armour (X+)" hidden="false" id="5073-af52-fe26-36ff" typeId="c14f-740-8107-d34b" typeName="Armour">
       <characteristics>

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -27,7 +27,7 @@
 Note that this special rule may only apply to a single, non-magical hand weapon and does not apply to a model&apos;s mount (should it have one). If the model is using two hand weapon or any other sort of weapon, this rule cease to apply.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spawn of Slaanesh" hidden="false" id="771c-aa7a-7d32-c9d9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spawn of Slaanesh" hidden="false" id="771c-aa7a-7d32-c9d9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Slaanesh have the Strike First special rule.</characteristic>
       </characteristics>
@@ -37,7 +37,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with the Mark of Chaos Undivided can re-roll any failed Fear, Panic or Terror tests.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ogre Charge" hidden="false" id="d256-85be-6fcc-1cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Ogre Charge" hidden="false" id="d256-85be-6fcc-1cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="64" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">The Armour Piercing characteristic of any Impact Hits caused by a midel with this special rule is improved by the current Rank Bonus of its unit.</characteristic>
       </characteristics>
@@ -62,7 +62,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 A Chaos Troll that is in base contact with an enemy model may make one additional attack each turn with this weapon. This attack must be made last, after all other attacks have been made (including Stomp Attacks), but hits automatically.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Rampant Mutation" hidden="false" id="f83f-94ab-eab5-46c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Rampant Mutation" hidden="false" id="f83f-94ab-eab5-46c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="63" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit&apos;s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, roll on the table below to determine which mutation it is currently affected with:
 
@@ -77,12 +77,12 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with the Mark of Khorne have the Frenzy special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spawn of Khorne" hidden="false" id="bc77-5785-84ff-6552" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spawn of Khorne" hidden="false" id="bc77-5785-84ff-6552" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Khorne have the Killing Blow special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spawn of Nurgle" hidden="false" id="586b-2803-1084-f05e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spawn of Nurgle" hidden="false" id="586b-2803-1084-f05e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Nurgle have the Poison Attacks special rule.</characteristic>
       </characteristics>
@@ -92,12 +92,12 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Chaos Dragon may use wither Dark Fire of Chaos or Fumes of Contagion during the Shooting phase of its turn. It cannot use both during the same turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spawn of Tzeentch" hidden="false" id="d3d3-e2a9-b492-9302" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spawn of Tzeentch" hidden="false" id="d3d3-e2a9-b492-9302" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Tzeentch have the Flaming Attacks and Magical Attacks special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Handler" hidden="false" id="e746-bbf6-d1b9-b9c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Handler" hidden="false" id="e746-bbf6-d1b9-b9c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="70" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A chaos Warhound Handler is a special type of character that can be taken as an upgrade to accompany a unit of Chaos Warhounds. During deployment, position a Chaos Warhound handler with its unit of Chaos Warhounds, as you would a character that has joined a unit. Once placed, a Chaos Warhound Handler cannot leave the unit. Unless this model is fleeing, friendly units of Chaos Warhounds that are within its Commanding range can use this model&apos;s Leadership instead of their own.</characteristic>
       </characteristics>
@@ -112,7 +112,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-1 Extra Attacks (D3). In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="76" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, make a Leadership test for this model. If this test is failed, roll immediately on the Hellcannon Missfire table.</characteristic>
       </characteristics>
@@ -137,7 +137,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; 5(10) AP-2(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3). This weapon shoots like a stone thrower, using the &apos;Bombardment&apos; special rule a 3&quot; blast template and the Hellcannon Misfire table. Any unit that suffers one or more unsaved wounds from this weapon must make a Panic test as if it had taken heavy casualties.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wilful Beast" hidden="false" id="1c17-a2e1-fd0a-3714" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Wilful Beast" hidden="false" id="1c17-a2e1-fd0a-3714" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="73" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of their turns, this model must make a Leadership test (using its own unmodified Leadership). If this test is passed, the rider is able to keep control of their mount. If however, this test is failed, the rider has lost control and their mount becomes subject to the Frenzy special rule until their next Start of Turn sub-phase.
 

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="13b1-ec94-d107-d711" name="Wood Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="6" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13b1-ec94-d107-d711" name="Wood Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="6" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Elven Reflexes" hidden="false" id="a8c1-1eef-eaba-d157" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -6,12 +6,12 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule (but not its mount) has a +1 modifier to its Initiative characteristic (to a maximum of 10) during the first round of any combat</characteristic>
       </characteristics>
     </profile>
-    <profile name="Talismanic Tattoos" hidden="false" id="2607-d20d-bd9a-871f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Talismanic Tattoos" hidden="false" id="2607-d20d-bd9a-871f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Talismanic Tattoos give their wearer a 6+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Tree Whack" hidden="false" id="1ca4-df5e-b2e7-9e1e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Tree Whack" hidden="false" id="1ca4-df5e-b2e7-9e1e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, during the Combat phase, a model with this special rule may use one of its Attacks to make a single Tree Whack attack. To make a Tree Whack attack, nominate a single model within an enemy unit that this model is engaged in combat
 with to be the target of the attack. That model must immediately make an Initiative test:
@@ -19,12 +19,12 @@ with to be the target of the attack. That model must immediately make an Initia
 • If the test is passed, the target manages to avoid the Tree Whack.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Tree Spirit" hidden="false" id="73e-df40-cff9-91af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Tree Spirit" hidden="false" id="73e-df40-cff9-91af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot join a unit without this special rule. A unit with this special rule cannot be joined by or use the Leadership characteristic of a character without this special rule. However, a unit with this special rule can use the Leadership characteristic of a friendly character with this special rule that is not fleeing whilst within that character’s Command range.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Woodland Ambush" hidden="false" id="954c-58d2-3702-51c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Woodland Ambush" hidden="false" id="954c-58d2-3702-51c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once players have finished placing terrains, a Wood Elf Realms player may place one additional wood measuring between 8’’ and 12’’ at its widest point. This may be placed anywhere on the battlefield that is not within their opponent&apos;s deployment zone and not within 12’’ of the centre of the battlefield.</characteristic>
       </characteristics>
@@ -110,7 +110,7 @@ charged. During a turn in which it was charged in its front arc, a model wieldin
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2, AP-2, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Guardians Of The Wildwood" hidden="false" id="ee3d-981c-3be0-7aef" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Guardians Of The Wildwood" hidden="false" id="ee3d-981c-3be0-7aef" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="130" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst it is on base contact with an enemy model that causes Fear or Terror, a model with this special rule gains a +1 modifier to its Attacks characteristics (to a maximum of 10) and the Multiple Wounds (2) special rule.</characteristic>
       </characteristics>
@@ -454,7 +454,7 @@ Notes: In combat, this model must make one of its attacks each turn with this we
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">8</characteristic>
       </characteristics>
     </profile>
-    <profile name="The Arrow Of Kurnous" hidden="false" id="9e77-e167-9d98-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="The Arrow Of Kurnous" hidden="false" id="9e77-e167-9d98-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="120" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once deployment is complete, but before the roll-off to determine which player takes the first turn, if the General of your opponent army is withing 36&quot; of one or more models of your army that has this special rule, one of those models may fire the Arrow of Kurnous. If the Arrow of Kurnous is fired, the General of your opponent&apos;s army inmediatly suffer a single Streght 3 hit, with no armour or Regeneration saves permitted (Ward saves can be attempted as normal).
 However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll when rolling off to determine who takes the first turn.</characteristic>
@@ -475,12 +475,12 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Attacks (+D3), Require Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Hawk-eyed Archer" hidden="false" id="f229-4b9d-faba-7568" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Hawk-eyed Archer" hidden="false" id="f229-4b9d-faba-7568" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="123" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule can target any enemy character it can draw a line of sight to, regardless of the usual rules for targeting Lone characters. In addition, a model with this special rule can target a specific model withing its target unit, such as a champion or a character.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Crown Of Antlers" hidden="false" id="d43d-b899-cd36-9ba7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Crown Of Antlers" hidden="false" id="d43d-b899-cd36-9ba7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="126" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have the Armour Bane (1) special ruleand an Armour Piercing characteristic of -1</characteristic>
       </characteristics>
@@ -521,7 +521,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72"/>
       </characteristics>
     </profile>
-    <profile name="Daughters Of Eternity" hidden="false" id="2eab-a965-2f01-1b5b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Daughters Of Eternity" hidden="false" id="2eab-a965-2f01-1b5b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="135" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 4+ Ward save against any wound suffered.</characteristic>
       </characteristics>


### PR DESCRIPTION
Issues:

- All the arcane journal tomb king page numbers are off (they all look like 60042717001) but that's fine since the arcane journal isn't in yet.
- No special rules imported from arcane journal kingdom of bretonnia. Does it even have any?
- any special rules that are duplicates didn't get page numbers. Currently my script lists 17 but any that exist in multiple publications (instead of twice in the same publication) will be duplicates.

How to replicate this:

- Create a folder called "raw". Add to it an epub of each book. 
- Create a publication for each book with an ID
- Rename each book to be "publication-id.epub"
- run read_from_epub in https://github.com/nstephenh/BSCopy
- - You will need to have python3, bs4, and  ebooklib installed. Will work on improving documentation later. 