### PR TITLE
Import special rules and profiles, fixing typos and adding characteristics

### DIFF
--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -81,12 +81,12 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
     </profile>
     <profile name="Wicked claws" hidden="false" id="7f7e-dcdb-43fe-ea61" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2</characteristic>
       </characteristics>
     </profile>
     <profile name="Slythey tongue" hidden="false" id="3e50-c9fe-dc8e-163d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, S5, AP -1, Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, S5, AP -1, Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Stony Stare" hidden="false" id="c32f-e4ed-cc42-69fc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="106" publicationId="7c89-736c-3139-24a0">
@@ -96,12 +96,12 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
     </profile>
     <profile name="Petrifying gaze" hidden="false" id="232-9631-9864-6533" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot;, S2, Magical Attacks, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot;, S2, Magical Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Acidic vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3, AP -1, Breath Weapon</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3, AP -1, Breath Weapon</characteristic>
       </characteristics>
     </profile>
     <profile name="Ghostsight" hidden="false" id="5b02-b6ce-8f7f-b393" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="7c89-736c-3139-24a0">
@@ -116,7 +116,7 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
     </profile>
     <profile name="Hurl attacks" hidden="false" id="4ae-a68d-e8bd-fc60" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-36&quot; S4(8), AP-1(-3), Bombardment, Cumbersome, Multiple Wounds (D3+1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-36&quot; S4(8), AP-1(-3), Bombardment, Cumbersome, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Storm Call" hidden="false" id="b8f1-3ef8-d7a2-509c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -132,7 +132,7 @@ Effect: If this Bound spell is cast, all unit whithing 6&quot; of this model (fr
     </profile>
     <profile name="Cleaver-limber" hidden="false" id="8f70-96a3-fd2b-4bc2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2, Killing Blow, Monster Slayer</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2, Killing Blow, Monster Slayer</characteristic>
       </characteristics>
     </profile>
     <profile name="Bray-Shaman" hidden="false" id="b6c-3d01-2443-8923" typeId="b070-143a-73f-2772" typeName="Model">
@@ -534,7 +534,7 @@ Effect: If this Bound spell is cast, all unit whithing 6&quot; of this model (fr
     </profile>
     <profile name="Giant´s club" hidden="false" id="742-e3dd-26f9-778f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9"/>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9"/>
       </characteristics>
     </profile>
     <profile name="Giant Attacks" hidden="false" id="8db2-4aff-79f-5386" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">

--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -101,6 +101,7 @@ Each time an enemy model is removed from play in this way, the Ghorgon recovers 
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">2</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">N/A</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Magical Attacks, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">When making a roll To Wound for an attack made with this weapon, substitute the target’s Toughness with its Initiative. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Acidic vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="106" publicationId="7c89-736c-3139-24a0">

--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -42,9 +42,10 @@ Note that this special rule may only be used by a Beastlord or Wargor that has b
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3&quot; or more, a model with this special rule gains a +1 modifier to its Strength characteristic.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Foe render" hidden="false" id="31c4-f186-18ba-cd04" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Foe render" hidden="false" id="31c4-f186-18ba-cd04" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilist subject to Primal Fury, a hand weapon carried by a model with this special rule has an Armour Piercing characteristic of -2.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst subject to Primal Fury, a hand weapon carried by a model with this special rule has an Armour Piercing characteristic of -2.
+Note that this special rule only applies to a single, non-magical hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
     <profile name="Swallow Whole" hidden="false" id="31dc-5b36-bbf8-bba3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="110" publicationId="7c89-736c-3139-24a0">

--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="eaaf-1e11-a32d-ab11" name="Beastmen Brayherds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="14" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="eaaf-1e11-a32d-ab11" name="Beastmen Brayherds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="14" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Blood Rage" hidden="false" id="8117-de6e-d7df-3eca" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If when testing to see if it becomes subject to Primal Fury, this unit passes its Leadership test with any roll of a natural double, it will also become Frenzied in this wayeven if it has lost Frenzied earlier in the game.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If, when testing to see if it becomes subject to Primal Fury (see page 116), this unit passes its Leadership test with any roll of a natural double, it will also become Frenzied. A unit with this special rule may become Frenzied in this way even if it has lost Frenzy earlier in the game.</characteristic>
       </characteristics>
     </profile>
     <profile name="Braystaff" hidden="false" id="583e-832e-5e02-23cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model´s combat is choosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must choose to use its Braystaff offensively or defensively. Used offensively, a Braystaff count as a great weapon. Used defensively, a Braystaff count as a hand weapon as gains its wieder an Armour Value of 5+.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must choose to use its Braystaff offensively or defensively. Used offensively, a Braystaff counts as a great weapon. Used defensively, a Braystaff counts as a hand weapon and gives its wielder an Armour Value of 5+.</characteristic>
       </characteristics>
     </profile>
     <profile name="Brayhorn" hidden="false" id="5706-b80f-ecc9-85ee" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="92" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">From the beginning of round 2 onwards, if you General is on the battlefield during the Command sub phase of their turn, they may attempt to sound the Brayhorn by making a Leadership test. If this test is passed, you may immediately roll again for each unit of Ambushers in the army that is hold in reserve and that did not arrive during the Start od Turn sub-phase of this turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">From the beginning of round 2 onwards, if your General is on the battlefield during the Command sub-phase of their turn, they may attempt to sound the Brayhorn by making a Leadership test. If this test is passed, you may immediately roll again for each unit of Ambushers in the army that is held in reserve and that did not arrive during the Start of Turn sub-phase of this turn.
+Note that this special rule may only be used by a Beastlord or Wargor that has been selected to be the General of the army.</characteristic>
       </characteristics>
     </profile>
     <profile name="Bull-gors" hidden="false" id="d485-902a-f6aa-8fbe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact hits caused by a model with this special rule have an Armour Piercing characteristic of -1</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Primal Fury" hidden="false" id="24a7-8ec2-fca1-21e2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit´s comabt is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is passed, the unit becomes &quot;Primal Fury&quot; until the end of the Combat phase. A unit Primal Fury may re-roll any rolls To Hit of a natural 1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is passed, the unit becomes subject to ‘Primal Fury’ until the end of this Combat phase. A unit subject to Primal Fury may re-roll any rolls To Hit of a natural 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ensorcelled Weapons" hidden="false" id="fe92-e9d9-91b4-e794" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -33,22 +34,12 @@
     </profile>
     <profile name="Drunken" hidden="false" id="7c-7525-760e-17ad" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, roll on the Drunken table for each unit with this special rule that is not currently Frenzied, that is not engaged in combat and that is not fleeing.
-
-Drunken Table
-D6
-1 - Unsteady: The unit has become somewhat unsteady. Until its next Start of Turn sub-phase, the unit is subject to the Random Movement special rule and its Movement characteristic becomes D6+2.
-
-
-2-5 - Sobering Up: The alcohol has not discernible effect upon the unit.
-
-
-6 - Belligerent Drunks: The unit has turned quite belligerent. Until the next Start of Turn sub-phase, the unit is subject to the Frenzy special rule. A unit whit this special rule may become Frenzied in this way even if it has lost Frenzy earlier in the game.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, roll on the Drunken table for each unit with this special rule that is not currently Frenzied, that is not engaged in combat and that is not fleeing:</characteristic>
       </characteristics>
     </profile>
     <profile name="Bestial Charge" hidden="false" id="4203-7f82-8eaa-bfd3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="97" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3 or more, a model with this special rule gain a +1 modifier to its Strengh characteristic.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3&quot; or more, a model with this special rule gains a +1 modifier to its Strength characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Foe render" hidden="false" id="31c4-f186-18ba-cd04" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -58,10 +49,10 @@ D6
     </profile>
     <profile name="Swallow Whole" hidden="false" id="31dc-5b36-bbf8-bba3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="110" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, a Ghorgon that is engaged in combat with one or more units of &quot;regular infantry&quot; or &quot;heavy infantry&quot; may choose to make &quot;Swallow Whole&quot; attack. To make Swallow Whole attack, nominate an enemy unit of regular or heavy infantry that the Ghorgon is engaged im combat with. The unit inmediately make an Initiative test.
-- If this test is failed, the Ghorgon grabs a victim from the unit and stuffs them into its gullet. A single model belonging to the target unit is inmediatly removed from play as casualty.
-- If this test is passed, the warriors manage to avoid the graping Ghorgon. No one is picked up and the attack has no effect.
-Each time an enemy model is removed from play in this way, the Ghorgon recover a single lost Wound.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, a Ghorgon that is engaged in combat with one or more units of ‘regular infantry’ or ‘heavy infantry’ may choose to make a ‘Swallow Whole’ attack. To make a Swallow Whole attack, nominate an enemy unit of regular or heavy infantry that the Ghorgon is engaged in combat with. The unit must immediately make an Initiative test:
+•	If this test is failed, the Ghorgon grabs a victim from the unit and stuffs them into its gullet. A single model belonging to the target unit is immediately removed from play as a casualty.
+•	If this test is passed, the warriors manage to avoid the grasping Ghorgon. No one is picked up and the attack has no effect.
+Each time an enemy model is removed from play in this way, the Ghorgon recovers a single lost Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Slaughterer´s Call" hidden="false" id="b97f-2f88-1a71-ecf1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -71,47 +62,63 @@ Each time an enemy model is removed from play in this way, the Ghorgon recover a
     </profile>
     <profile name="Maddening Aura" hidden="false" id="dfb4-a590-c057-c4f1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, any enemy unit that is withing 8&quot; of this model, including units that are fleeing or that are engaged in combat, must take a Leadership test. If this test is failed, the unit suffers D3 Strenght 3 Hits with no armour or Regeneration saves permited (Ward saves can be attempted as normal).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of its turn, any enemy unit that is within 8&quot; of this model, including units that are fleeing or that are engaged in combat, must make a Leadership test. If this test is failed, the unit suffers D3 Strength 3 hits, with no armour or Regeneration saves permitted (Ward saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Spurting Bile Blood" hidden="false" id="2e29-8f80-1a23-dbdb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">For each Wound this model loses during the Combat phase, the attacking enemy unit suffer a Strength 4 hit with an AP of -1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">For each Wound this model loses during the Combat phase, the attacking enemy unit suffers a Strength 4 hit, with an AP of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wicked claws" hidden="false" id="7f7e-dcdb-43fe-ea61" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Wicked claws" hidden="false" id="7f7e-dcdb-43fe-ea61" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="177" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Slythey tongue" hidden="false" id="3e50-c9fe-dc8e-163d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Slythey tongue" hidden="false" id="3e50-c9fe-dc8e-163d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, S5, AP -1, Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Stony Stare" hidden="false" id="c32f-e4ed-cc42-69fc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="106" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">At the start of each Combat phase, enemy models in base contact with this model must make an Initiative test. If this test is failed, the suffer D3 Strength 2 hits, with no armour save permitted (Ward and Regeneration saves can be attempted as normal)</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">At the start of each Combat phase, enemy models in base contact with this model must make an Initiative test. If this test is failed, they suffer D3 Strength 2 hits, with no armour save permitted (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Petrifying gaze" hidden="false" id="232-9631-9864-6533" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Petrifying gaze" hidden="false" id="232-9631-9864-6533" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot;, S2, Magical Attacks, Multiple Wounds (D3)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">18&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">N/A</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Magical Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Acidic vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Acidic vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="106" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3, AP -1, Breath Weapon</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon</characteristic>
       </characteristics>
     </profile>
     <profile name="Ghostsight" hidden="false" id="5b02-b6ce-8f7f-b393" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a Cygor may re-roll any failed roll To Hit made against enemy Wizards, enemy models or units equipped with any magic items, or enemy models or units with Ward or Regeneration save.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a Cygor may re-roll any failed rolls To Hit made against enemy Wizards, enemy models or units equipped with any magic items, or enemy models or units with a Ward or Regeneration save.</characteristic>
       </characteristics>
     </profile>
     <profile name="Soul-eater" hidden="false" id="b06f-c50f-6546-509c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy Wizzard that wishes to start a spell whilist or withing 12&quot; of one or more Cygor unit, first make a Leadership test. If this test is failed, the Wizzard has lost their nerve and, should they fail to cast the spell, the spell has been misscast and the active player inmediatly roll on the Misscast table to see what fate bafalls the unfortunate Wizzard. If this test is passed, the Wizzard can continue with their casting attempt as normal.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy Wizard that wishes to cast a spell whilst within 12&quot; of one or more Cygors must first make a Leadership test. If this test is failed, the Wizard has lost their nerve and, should they fail to cast the spell (i.e., should their casting result be less than the casting value of the spell), the spell has been miscast and the active player immediately rolls on the Miscast table to see what fate befalls the unfortunate Wizard. If this test is passed, the Wizard can continue with their casting attempt as normal.</characteristic>
       </characteristics>
     </profile>
     <profile name="Hurl attacks" hidden="false" id="4ae-a68d-e8bd-fc60" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -506,17 +513,18 @@ Effect: If this Bound spell is cast, all unit whithing 6&quot; of this model (fr
     </profile>
     <profile name="Blood Greed" hidden="false" id="5e04-be01-6254-98b9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="115" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilist Frenzied, this model has a +2 modifier to its Attacks characteristic (rather that the usual +1) However, such is this model´s desperate need to feed upon flesh that it rolls only a single D6 when making a Pursuit roll (rather than the usual 2D6)</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst Frenzied, this model has a +2 modifier to its Attacks characteristic (rather than the usual +1). However, such is this model’s desperate need to feed upon flesh that it rolls only a single D6 when making a Pursuit roll (rather than the usual 2D6).</characteristic>
       </characteristics>
     </profile>
     <profile name="The Quickening Storm" hidden="false" id="74d8-efb5-1253-cb99" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wound suffered that were made by a Magic Misile or a Magical Vortex spell. In addition, if a  model with this special rule, or the unit it belongs to suffer one or more hits from Storm Call, it become Quickening. A Quickening model has a +1 modifier to both its Leadeship and Attacks characteristic. This Quickening last until your next Start of Turn sub-phase.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by a Magic Missile or a Magical Vortex spell. In addition, if a model with this special rule, or the unit it belongs to, suffers one or more hits from Storm Call (see page 104), it becomes ‘Quickened’. A Quickened model has a +1 modifier to both its Initiative and Attacks characteristics. This Quickening lasts until your next Start of Turn sub-phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Razor Tusks" hidden="false" id="3650-49a2-85b-702e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="116" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, the Armour Penetration characteristic of a Tuskgor or Razorgor tusk (hand weapon) is improved by 1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, the Armour Piercing characteristic of a Tuskgor’s or Razorgor’s tusks (hand weapon) is improved by 1.
+Note that this special rule only applies to attacks made by a Tuskgor or Razorgor, not to a chariot or its crew.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chaos Giant" hidden="false" id="ee66-59bb-e469-d121" typeId="b070-143a-73f-2772" typeName="Model">

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="f8cb-e518-1881-292" name="Bretonnians" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="1" revision="42" authorUrl="www.newrecruit.eu" authorContact="newrecruit.eu@gmail.com" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f8cb-e518-1881-292" name="Bretonnians" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="1" revision="42" authorUrl="www.newrecruit.eu" authorContact="newrecruit.eu@gmail.com" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile typeId="b070-143a-73f-2772" id="cd5f-980c-2da9-31b" name="Grail Knight" hidden="false" publicationId="3a81ff07--pubd1e638" typeName="Model">
       <characteristics>
@@ -114,7 +114,7 @@ Note that a Field Trebuchet can still pivot freely at any time during its turn, 
     </profile>
     <profile name="Blessed Triptych" hidden="false" id="dff9-cd97-d1c-ab35" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="92" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit that contains a mode equipped with a Blessed Triptych gains the Stubborn special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit that contains a model equipped with a Blessed Triptych gains the Stubborn special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Polearm" hidden="false" id="1f2e-63ae-b4e4-c501" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -130,26 +130,20 @@ Double handed: S+1 AP1 Requires Two Hands</characteristic>
     </profile>
     <profile name="Burning Braziers" hidden="false" id="3e5f-babb-4f9b-76c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The longbows of a unit equipped with burning braziers gain the Flamming Attacks special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The longbows of a unit equipped with burning braziers gain the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Defensive Stakes" hidden="false" id="642d-3ed8-534e-3e52" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit equipped with Defensive Stakes is deployed, the stakes are place in base contact with its front arc and will remain there for the duration of the game, unless the unit moves - should the unit move for any reason (including reforming), the stakes are lost and are removed from play. All measurements to and from the unit is done from the unit itself, ignore the stakes.
-
-
-Enemy units can charge the front of a unit equipped with Defensive Stakes as normal but do not have to physically  cross the stakes to do so. Instead, the front rank of a charging unit moves into base contact with the stakes, making a disordered charge and becoming Disrupted. A model whose troop type is &apos;cavalry&apos; or &apos;chariot&apos; must make a Dangerous Terrain test if it ends its charge move in base contact with the stakes.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit equipped with defensive stakes is deployed, the stakes are placed in base contact with its front arc and will remain there for the duration of the game, unless the unit moves – should the unit move for any reason (including reforming), the stakes are lost and are removed from play. All measurement to and from the unit is done from the unit itself – ignore the stakes.
+Enemy units can charge the front of a unit equipped with defensive stakes as normal but do not have to physically cross the stakes to do so. Instead, the front rank of a charging unit moves into base contact with the stakes, making a disordered charge and becoming Disrupted. A model whose troop type is ‘cavalry’ or ‘chariot’ must make a Dangerous Terrain test if it ends its charge move in base contact with the stakes.</characteristic>
       </characteristics>
     </profile>
     <profile name="Grail Reliquae" hidden="false" id="6e4e-5dbf-b254-52b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="94" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Grail Reliquar is placed in the centre of the front tank of its unit (or as close to the centre as possible) and occupies the space of and counts as six models, tow in the first rank, two in the second and two in the third. If the unit turns or reforms, the Grail Reliquar must be repositioned into the new front rank.
-
-
-Casualties are removed from the unit as normal, but the Grail Reliquar cannot lose any Wounds whilst any Battle Pilgrim remains. Only once all of the Battle Pilgrims have been removed from the unit can the Grail Reliquar itself lose Wounds.
-
-
-The Grail Reliquar counts as both standard bearer and a musician for the unit. Whilst the Grail Reliquar model itself is within 12&quot; of a friendly model that has the Grail Vow and is not fleeing, its unit gains Immune to Psychology and Unbreakable special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Grail Reliquae is placed in the centre of the front rank of its unit (or as close to the centre as possible) and occupies the space of, and counts as, six models; two in the front rank, two in the second and two in the third. If the unit turns or reforms, the Grail Reliquae must be repositioned into the new front rank.
+Casualties are removed from the unit as normal, but the Grail Reliquae cannot lose any Wounds whilst any Battle Pilgrims remain. Only once all of the Battle Pilgrims have been removed from the unit can the Grail Reliquae itself lose Wounds.
+The Grail Reliquae counts as both a standard bearer and a musician for its unit. Whilst the Grail Reliquae model itself is within 12&quot; of a friendly model that has the Grail Vow and is not fleeing, its unit gains the Immune to Psychology and Unbreakable special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Retinue of the Saints" hidden="false" id="f128-f8cd-3184-ff0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -159,12 +153,12 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
     </profile>
     <profile name="Living Saints" hidden="false" id="1113-147a-4ed6-67ce" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="97" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Every model in a unit of Grail Knights can issue and accept challenges in the same manner that a character.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Every model in a unit of Grail Knights can issue and accept challenges in the same manner as a character.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dispersed Formation" hidden="false" id="2a78-f58a-ac7f-87ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="98" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">While in Skirmish formation, every model in a unit of Pegasus Knights must be within 2&quot; of another model belonging to the same unit, rather tan the usual 1&quot;.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst in Skirmish formation, every model in a unit of Pegasus Knights must be within 2&quot; of another model belonging to the same unit, rather than the usual 1&quot;.</characteristic>
       </characteristics>
     </profile>
     <profile name="Field Trebuchet" hidden="false" id="948b-a40d-9586-fb3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -434,7 +428,9 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
     </profile>
     <profile name="The Grail Vow" hidden="false" id="c4ac-f6a7-2481-db1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="108" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this Chivalrous Vow has the Immune to Psychology, Magical Attacks and Stubborn special rules. In addition, models with this Chivalrous Vow always benefit from the Blessings of the Lady special rule and do not have to pray at the start of the game. However, a model with this Chivalrous Vow cannot refuse a challenge.
+A unit with this Chivalrous Vow can only be joined by a character that also has this Chivalrous Vow or by a Handmaiden of the Lady. A character with this Vow cannot join a unit with the Peasantry special rule.
+Many models in the Kingdom of Bretonnia army list have one of the following Chivalrous Vows listed among their special rules. Of those that do, some have the option to replace it with another Chivalrous Vow:</characteristic>
       </characteristics>
     </profile>
     <profile name="The Knight&apos;s Vow" hidden="false" id="8ce9-c356-89db-b011" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -449,12 +445,12 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
     </profile>
     <profile name="Lance Formation" hidden="false" id="cc9a-f69f-d2e7-b352" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Lance formation.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Lance formation, as described on page 110.</characteristic>
       </characteristics>
     </profile>
     <profile name="Peasantry" hidden="false" id="36a8-2e1e-31ba-afae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule is within 6&quot; of a friendly model that has the Knight&apos;s Vow, the Questing Vow or the Grail Vow, and if that model is not fleeing, this unit can use that model&apos;s Leadership characteristic instead of its own. In addition, a standard carried by a unit with this special rule cannot be counted as a trophy of war. A character with this special rule can only join a unit that also has this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule is within 6&quot; of a friendly model that has the Knight’s Vow, the Questing Vow or the Grail Vow, and if that model is not fleeing, this unit can use that model’s Leadership characteristic instead of its own. In addition, a standard carried by a unit with this special rule cannot be counted as a trophy of war. A character with this special rule can only join a unit that also has this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Blessings of the Lady" hidden="false" id="e8e9-e956-786-d941" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -464,7 +460,7 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
 - A 5+ Ward save against any wounds suffered that were caused by an attack with a Strength 5 or higher.
 
 
-Note that if there is no roll-off to determine which player takes the first turn, the Bretonnian army cannot kneel and pray for the Blessing. Note also that, should two Bretonnina armies face one another, neither may use this special rule.
+Note that if there is no roll-off to determine which player takes the first turn, the Bretonnian army cannot kneel and pray for the Blessing. Note also that, should two Bretonnina armies face one another, neither may use this special rule.
 
 
 Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can be list during a game. Any model or unit that flees, or any character that refuses a challenge, will immediately lose this special rule. For the purpose of this special rule, Falling Back in Good Order does not count as fleeing.</characteristic>
@@ -472,7 +468,8 @@ Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can 
     </profile>
     <profile name="The Questing Vow" hidden="false" id="1439-c8b1-9ff8-298a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="108" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this Chivalrous Vow has the Stubborn special rule and can re-roll any failed Fear, Panic or Terror test. In addition, a model with this Chivalrous Vow does not have to make a Panic test when a friendly unit with the Peasantry special rule is destroyed whilst within 6&quot; of it, or when it is fled through by a friendly unit with the Peasantry special rule. However, a model with this Chivalrous Vow cannot be equipped with a lance (be it magical or mundane).
+A unit with this Chivalrous Vow cannot be joined by a character that has the Knight’s Vow or the Peasantry special rule. A character with this Chivalrous Vow cannot join a unit with the Peasantry special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Virtue of Knightly Temper" hidden="false" id="b761-54dc-9c80-5a5e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -537,7 +534,7 @@ Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can 
     </profile>
     <profile name="Virtue of The Joust" hidden="false" id="9d61-74e-efa8-39b0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this Virtue may re-roll any failed rolls To Wound made when  using a lance.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this Virtue may re-roll any failed rolls To Wound made when  using a lance.</characteristic>
       </characteristics>
     </profile>
     <profile name="Virtue of Empathy" hidden="false" id="38cd-2179-c9d7-a497" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -119,7 +119,7 @@ Note that a Field Trebuchet can still pivot freely at any time during its turn, 
     </profile>
     <profile name="Polearm" hidden="false" id="1f2e-63ae-b4e4-c501" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Single handed: Fight in Extra Rank
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Single handed: Fight in Extra Rank
 Double handed: S+1 AP1 Requires Two Hands</characteristic>
       </characteristics>
     </profile>
@@ -169,7 +169,7 @@ The Grail Reliquar counts as both standard bearer and a musician for the unit. W
     </profile>
     <profile name="Field Trebuchet" hidden="false" id="948b-a40d-9586-fb3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-72&quot; S5(10) AP-1(-4) Bombardment, Cumbersome, Immovable Object, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-72&quot; S5(10) AP-1(-4) Bombardment, Cumbersome, Immovable Object, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Duke" hidden="false" id="91bb-f98c-bfe-2295" typeId="b070-143a-73f-2772" typeName="Model">

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -123,9 +123,9 @@ Note that a Field Trebuchet can still pivot freely at any time during its turn, 
 Double handed: S+1 AP1 Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Shield of the Lady" hidden="false" id="58ff-56d9-4cba-ccc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Shield of the Lady" hidden="false" id="58ff-56d9-4cba-ccc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="87" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this characteristic has joined a unit that has a Unit Strength of 10 or more, and that has a Chivalrous Vow, they may voluntarily &apos;retire&apos; in the rear of the unit at any time, moving through the ranks and taking up a position away from the combat. Should they do so, they are no longer within the fighting rank and cannot make any attacks or have attacks directed against them. However, they continue to confer benefits to the unit in the form of Leadership and special rules, and they cast spells as if they were within the fighting rank.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character has joined a unit that has a Unit Strength of 10 or more, and that has a Chivalrous Vow (see page 108), they may voluntarily ‘retire’ to the rear of the unit at any time, moving through the ranks and taking up a position away from the combat. Should they do so, they are no longer within the fighting rank and cannot make any attacks or have attacks directed against them. However, they continue to confer benefits to the unit in the form of Leadership and special rules, and may cast spells as if they were within the fighting rank.</characteristic>
       </characteristics>
     </profile>
     <profile name="Burning Braziers" hidden="false" id="3e5f-babb-4f9b-76c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="93" publicationId="8b8d-8fc4-559e-87b1">
@@ -146,9 +146,9 @@ Casualties are removed from the unit as normal, but the Grail Reliquae cannot lo
 The Grail Reliquae counts as both a standard bearer and a musician for its unit. Whilst the Grail Reliquae model itself is within 12&quot; of a friendly model that has the Grail Vow and is not fleeing, its unit gains the Immune to Psychology and Unbreakable special rules.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Retinue of the Saints" hidden="false" id="f128-f8cd-3184-ff0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Retinue of the Saints" hidden="false" id="f128-f8cd-3184-ff0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="94" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include up to one Grail Reliquar for every character or unit with the Grail Vow it includes.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include up to one Grail Reliquae for every character or unit with the Grail Vow it includes.</characteristic>
       </characteristics>
     </profile>
     <profile name="Living Saints" hidden="false" id="1113-147a-4ed6-67ce" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="97" publicationId="8b8d-8fc4-559e-87b1">
@@ -453,17 +453,15 @@ Many models in the Kingdom of Bretonnia army list have one of the following Chiv
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule is within 6&quot; of a friendly model that has the Knight’s Vow, the Questing Vow or the Grail Vow, and if that model is not fleeing, this unit can use that model’s Leadership characteristic instead of its own. In addition, a standard carried by a unit with this special rule cannot be counted as a trophy of war. A character with this special rule can only join a unit that also has this special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blessings of the Lady" hidden="false" id="e8e9-e956-786-d941" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blessings of the Lady" hidden="false" id="e8e9-e956-786-d941" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="107" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once the deployment is complete, instead of rolling off to determine which player takes the first turn, the Bretonnian army may kneel and pray for the Blessings of the Lady. If it does so, the opposing player counts as having won the roll-off and the Lady&apos;s Blessing is granted, giving all models in the Bretonnian army with this special rule:
-- A 6+ Ward save against any wounds suffered.
-- A 5+ Ward save against any wounds suffered that were caused by an attack with a Strength 5 or higher.
-
-
-Note that if there is no roll-off to determine which player takes the first turn, the Bretonnian army cannot kneel and pray for the Blessing. Note also that, should two Bretonnina armies face one another, neither may use this special rule.
-
-
-Loosing the Blessing: Unlike other special rules, the Blessings of the Lady can be list during a game. Any model or unit that flees, or any character that refuses a challenge, will immediately lose this special rule. For the purpose of this special rule, Falling Back in Good Order does not count as fleeing.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once deployment is complete, instead of rolling off to determine which player takes the first turn, the Kingdom of Bretonnia army may kneel and pray for the Blessings of the Lady. If it does so, the opposing player counts as having won the roll-off and the Lady’s Blessing is granted, giving all models in the Kingdom of Bretonnia army with this special rule:
+•	A 6+ Ward save against any wounds suffered.
+•	A 5+ Ward save against any wounds suffered that were caused by an attack with a Strength of 5 or higher.
+Note that if there is no roll-off to determine which player takes the first turn, the Kingdom of Bretonnia army cannot kneel and pray for the Blessing.
+Note also that, should two Kingdom of Bretonnia armies face one another, neither may kneel and pray for the Blessings of the Lady. The Lady will not give her blessings to those that wage internecine wars, and no knight would presume to ask!
+Losing The Blessing: Unlike other special rules, the Blessings of the Lady can be lost during a game. Any model or unit that flees, or any character that refuses a challenge, will immediately lose this special rule.
+Note that, for the purposes of this special rule, Falling Back in Good Order does not count as fleeing.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Questing Vow" hidden="false" id="1439-c8b1-9ff8-298a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="108" publicationId="8b8d-8fc4-559e-87b1">

--- a/Common Magic Items.cat
+++ b/Common Magic Items.cat
@@ -3373,7 +3373,7 @@ Whilst transmogrified, the Wizard cannot cast or dispel any spells, cannot use a
     </profile>
     <profile name="Filth Mace" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="d2a5-84a-c013-53a6">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+1  AP-1 [Magical Attacks] Any enemy model that suffers one or more unsaved wounds from the Filth Mace must immediately make a Toughness test. If failed, the wounded model suffers a -1 modifier to its Toughness characteristic (to a minimum of 1) until the end of the turn.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+1  AP-1 [Magical Attacks] Any enemy model that suffers one or more unsaved wounds from the Filth Mace must immediately make a Toughness test. If failed, the wounded model suffers a -1 modifier to its Toughness characteristic (to a minimum of 1) until the end of the turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chaos Runesword" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="545-a33a-698d-3cb1">
@@ -3520,7 +3520,7 @@ Note that this does not increase the Wizard&apos;s Level.</characteristic>
     </profile>
     <profile name="Standard of the Cursing Word" hidden="false" id="d9e6-8ccb-3158-dc01" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Battle Standard Bearer only. At the end of any phase in which one or more models in a unit joined by the bearer of the Standard of the Cursing World lost its last Wound to an enemy attack, the unit that made the attack must make a Leadership test. If this test is failed, the enemy unit suffers D3 Strength 2 hits, each with an Ap of -, for each model that lost its last Wound.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Battle Standard Bearer only. At the end of any phase in which one or more models in a unit joined by the bearer of the Standard of the Cursing World lost its last Wound to an enemy attack, the unit that made the attack must make a Leadership test. If this test is failed, the enemy unit suffers D3 Strength 2 hits, each with an Ap of -, for each model that lost its last Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Banner of Outrage" hidden="false" id="a2d2-43dd-ca64-8234" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
@@ -3580,7 +3580,7 @@ Note that this does not increase the Wizard&apos;s Level.</characteristic>
     </profile>
     <profile name="Bow of Loren" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="c04c-1af4-e634-241d">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">32&quot; S5  [Armour Bane (1)], [Magical Attacks] The Bow of Loren counts as an [Asrai Longbow]. The wielder of the Bow of Loren may make a number of shooting attacks equal to their Attacks characteristic, rather than the usual one. The model does not suffer any modifier for firing multiple shots.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">32&quot; S5  [Armour Bane (1)], [Magical Attacks] The Bow of Loren counts as an [Asrai Longbow]. The wielder of the Bow of Loren may make a number of shooting attacks equal to their Attacks characteristic, rather than the usual one. The model does not suffer any modifier for firing multiple shots.</characteristic>
       </characteristics>
     </profile>
     <profile name="Blades of Loec" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="b975-7f09-e6d9-a31b">
@@ -3813,7 +3813,7 @@ Double Handed: S10 AP-5 [Magical Attacks], [Multiple Wounds (D6)], [Requires Two
     </profile>
     <profile name="Destroyer of Eternities" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="e6ee-8151-4b87-9fad">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-2 [Killing Blow], [Magical Attacks], [Requires Two Hands], [Strike Last] Rather than attacking normally, the wielder of the Destroyer of Eternities may choose to make a special ’Scything’ attack. If they do, the enemy unit they are directing their attacks against suffers D6 automatic hits, each resolved using the Destroyer of Eternities profile.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-2 [Killing Blow], [Magical Attacks], [Requires Two Hands], [Strike Last] Rather than attacking normally, the wielder of the Destroyer of Eternities may choose to make a special ’Scything’ attack. If they do, the enemy unit they are directing their attacks against suffers D6 automatic hits, each resolved using the Destroyer of Eternities profile.</characteristic>
       </characteristics>
     </profile>
     <profile name="Wollopa&apos;s One Hit Wunds" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="b6f3-e7cd-f2f3-41d9">
@@ -3968,17 +3968,17 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Blade of Antarhak" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="362a-724c-9882-b30b">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+1 AP-1 [Magical Attacks] The Blade of Antarhak may only be taken by models in a Nehekharan Royal Host, Army of Infamy. For each Wound an enemy unit loses as a result of an attack made with the Blade of Antarhak, its wielder immediately recovers a single lost Wound.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+1 AP-1 [Magical Attacks] The Blade of Antarhak may only be taken by models in a Nehekharan Royal Host, Army of Infamy. For each Wound an enemy unit loses as a result of an attack made with the Blade of Antarhak, its wielder immediately recovers a single lost Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Crook &amp; Flail of Radiance" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="7605-f5b9-f6e6-40e0">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">AP-1 [Extra Attacks (+D3)], [Magical Attacks], [Requires Two Hands], [Strike First] Monarchs of Nehekhara only.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">AP-1 [Extra Attacks (+D3)], [Magical Attacks], [Requires Two Hands], [Strike First] Monarchs of Nehekhara only.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Conqueror’s Blade" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="d51a-cf92-9fc2-22e2">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-2 [Killing Blow], [Magical Attacks], [Requires Two Hands], [Strike Last] Whilst engaged on a challenge, the bearer of the Conqueror’s Blade strike a Killing Blow if they roll a natural 5 or 6 when making a To Wound roll, rather than the usual 6. In addition, should the wielder slay the enemy General in a challenge, you win a bonus of 100 Victory Points at the end of the game.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-2 [Killing Blow], [Magical Attacks], [Requires Two Hands], [Strike Last] Whilst engaged on a challenge, the bearer of the Conqueror’s Blade strike a Killing Blow if they roll a natural 5 or 6 when making a To Wound roll, rather than the usual 6. In addition, should the wielder slay the enemy General in a challenge, you win a bonus of 100 Victory Points at the end of the game.</characteristic>
       </characteristics>
     </profile>
     <profile name="Serpent Staff" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="e0a3-a833-cbcf-6c8">
@@ -3988,57 +3988,57 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Staff of Aeons" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="7834-18b9-4559-9353">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-1 [Magical Attacks], [Requires Two Hands] The Staff of Aeons may only be taken by a Liche Priest in a Mortuary Cult Army of Infamy. Any model that is hit by one or more close combat attacks made using this weapon suffers a -1 modifier to its armour value for the remainder of the game.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">S+2 AP-1 [Magical Attacks], [Requires Two Hands] The Staff of Aeons may only be taken by a Liche Priest in a Mortuary Cult Army of Infamy. Any model that is hit by one or more close combat attacks made using this weapon suffers a -1 modifier to its armour value for the remainder of the game.</characteristic>
       </characteristics>
     </profile>
     <profile name="Phakth’s Blades of Justice" typeId="b6b3-b419-b836-96b4" typeName="Magic Weapons" hidden="false" id="1e45-fa8f-a87f-6857">
       <characteristics>
-        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">AP-1 [Magical Attacks], [Requires Two Hands] Models whose troop type is ’infantry’ only. Phakth’s Blades of Justice grant the wielder +1 Attack for each rank an enemy unit the wielder is engaged with has.</characteristic>
+        <characteristic name="Description" typeId="cd52-e81e-d21c-af77">AP-1 [Magical Attacks], [Requires Two Hands] Models whose troop type is ’infantry’ only. Phakth’s Blades of Justice grant the wielder +1 Attack for each rank an enemy unit the wielder is engaged with has.</characteristic>
       </characteristics>
     </profile>
     <profile name="Armour of the Ages" hidden="false" id="fd17-a820-3d4a-77d4" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Armour of the Ages is a suit of light armour. In addition, enemy models must re-roll successful rolls To Wound made against the wearer.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Armour of the Ages is a suit of light armour. In addition, enemy models must re-roll successful rolls To Wound made against the wearer.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shield of Ptra" hidden="false" id="9ec6-4cab-27ff-f9b3" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Shield of Ptra is a shield. In addition, any enemy model that directs their attacks against the bearer during the Combat phase suffers a -1 modifier to their Weapon Skill characteristic.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Shield of Ptra is a shield. In addition, any enemy model that directs their attacks against the bearer during the Combat phase suffers a -1 modifier to their Weapon Skill characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warding Splint" hidden="false" id="8c5f-a8f4-9972-76fe" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Warding Splint is a suit of heavy armour which may be purchased and worn by a Liche Priest, even if they do not have the option to be equipped with armour, a shield or barding, without penalty. In addition, its wearer has a 5+ Ward save against any wounds suffered.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Warding Splint is a suit of heavy armour which may be purchased and worn by a Liche Priest, even if they do not have the option to be equipped with armour, a shield or barding, without penalty. In addition, its wearer has a 5+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
     <profile name="Royal Mantle" hidden="false" id="fee4-8472-b3b8-5a9f" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Royal Mantle may only be taken by models in a Nehekharan Royal Host Army of Infamy. May be worn with other armour. The wearer of the Royal Mantle improves their armour value by 1 (to a maximum of 2+). In addition, the wearer’s [My Will Be Done] special rule affects all friendly units with the Nehekharan Undead special rule within 6’’ of them, not just the unit they have joined.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Royal Mantle may only be taken by models in a Nehekharan Royal Host Army of Infamy. May be worn with other armour. The wearer of the Royal Mantle improves their armour value by 1 (to a maximum of 2+). In addition, the wearer’s [My Will Be Done] special rule affects all friendly units with the Nehekharan Undead special rule within 6’’ of them, not just the unit they have joined.</characteristic>
       </characteristics>
     </profile>
     <profile name="Amulet of the Serpent" hidden="false" id="f49b-4593-5b49-e3b7" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The bearer of the Amulet of the Serpent and any unit they have joined gains the [Poisoned Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The bearer of the Amulet of the Serpent and any unit they have joined gains the [Poisoned Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Relic of The Desert Sun" hidden="false" id="3965-4069-93af-b846" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The bearer of the Relic of the Desert Sun is not subject to the [Dry as Dust] or [Flammable] special rules.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The bearer of the Relic of the Desert Sun is not subject to the [Dry as Dust] or [Flammable] special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Collar of Shapesh" hidden="false" id="94cc-e3fe-4196-35cf" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Single use. When the wearer of the Collar of Shapesh loses their last Wound, roll a D6. On a roll of 4+, the Wound is not lost. Instead, a single friendly model within the wearer’s Command range is removed from play as a casualty.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Single use. When the wearer of the Collar of Shapesh loses their last Wound, roll a D6. On a roll of 4+, the Wound is not lost. Instead, a single friendly model within the wearer’s Command range is removed from play as a casualty.</characteristic>
       </characteristics>
     </profile>
     <profile name="Crown of Kings" hidden="false" id="2d44-7aa4-864b-91ac" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Monarch of Nehekhara only. During the command sub-phase of their turn, if they are not engaged in combat, the wearer of a Crown of Kings may attempt to resurrect the fallen by making a Leadership test. If this test is passed, a single friendly unit of Skeleton Warriors, Skeleton Archers, Skeleton Horsemen or Skeleton Horse Archers that is within the model’s Command range Recovers D3+1 Wounds.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Monarch of Nehekhara only. During the command sub-phase of their turn, if they are not engaged in combat, the wearer of a Crown of Kings may attempt to resurrect the fallen by making a Leadership test. If this test is passed, a single friendly unit of Skeleton Warriors, Skeleton Archers, Skeleton Horsemen or Skeleton Horse Archers that is within the model’s Command range Recovers D3+1 Wounds.</characteristic>
       </characteristics>
     </profile>
     <profile name="Icon of the Sacred Eye" hidden="false" id="5fc4-abdd-875d-e86b" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">A unit carrying the Icon of the Scared Eye has a +1 modifier to its Weapon Skill characteristic (to a maximum of 10).</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">A unit carrying the Icon of the Scared Eye has a +1 modifier to its Weapon Skill characteristic (to a maximum of 10).</characteristic>
       </characteristics>
     </profile>
     <profile name="0" hidden="false" id="f361-d1d6-a16c-a9a3" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
@@ -4048,62 +4048,62 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Mirage Banner" hidden="false" id="ed6c-cc0d-544b-ab94" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Any enemy model that targets a unit carrying the Mirage Banner during the Shooting phase suffers an additional -1 To Hit modifier.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Any enemy model that targets a unit carrying the Mirage Banner during the Shooting phase suffers an additional -1 To Hit modifier.</characteristic>
       </characteristics>
     </profile>
     <profile name="Banner of the Desert Winds" hidden="false" id="7b3e-1007-2e33-9cf5" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Models whose troop type is ‘infantry’ only. A unit carrying the Banner of the Desert Winds gains the [Vanguard] and [Reserve Move] special rules.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Models whose troop type is ‘infantry’ only. A unit carrying the Banner of the Desert Winds gains the [Vanguard] and [Reserve Move] special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Tapestry of Conquered Lands" hidden="false" id="2b85-5798-e97-a69" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Any enemy standard captured by a unit carrying the Tapestry of Conquered Lands is worth 100 Victory Points as a trophy of war.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Any enemy standard captured by a unit carrying the Tapestry of Conquered Lands is worth 100 Victory Points as a trophy of war.</characteristic>
       </characteristics>
     </profile>
     <profile name="Icon of Rakaph" hidden="false" id="823b-ea1a-3099-d6a6" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Unless making a charge move, a unit carrying the Icon of Rakaph may perform a single free reform at any point during its movement.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Unless making a charge move, a unit carrying the Icon of Rakaph may perform a single free reform at any point during its movement.</characteristic>
       </characteristics>
     </profile>
     <profile name="Sigil of Centuries" hidden="false" id="477b-3c5-cdc3-f36b" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">All enemy units within 6’’ of the model carrying the Sigil of Centuries suffers a -1 modifier to their Initiative characteristic (to a minimum of 1).</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">All enemy units within 6’’ of the model carrying the Sigil of Centuries suffers a -1 modifier to their Initiative characteristic (to a minimum of 1).</characteristic>
       </characteristics>
     </profile>
     <profile name="Royal Standard Of Settra" hidden="false" id="bd75-2ff0-231d-f93b" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">The Royal Standard of Settra may only be taken in a muster list that includes Settra the Imperishable and /or Nekaph Emissary of Settra. A unit carrying the Royal Standard of Settra gains the [Hatred] (enemy characters) and [Terror] special rules.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">The Royal Standard of Settra may only be taken in a muster list that includes Settra the Imperishable and /or Nekaph Emissary of Settra. A unit carrying the Royal Standard of Settra gains the [Hatred] (enemy characters) and [Terror] special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Cloak of the Dunes" hidden="false" id="50b-8181-7ff1-7bee" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Models whose troop type is ‘infantry’ only. The wearer of the Cloak of the Dunes gains the [Fly (9)] special rule. In addition, any enemy unit the wearer moves over during the Remaining Moves sub-phase suffers D6 Strength 2 hits, each with an AP of -1.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Models whose troop type is ‘infantry’ only. The wearer of the Cloak of the Dunes gains the [Fly (9)] special rule. In addition, any enemy unit the wearer moves over during the Remaining Moves sub-phase suffers D6 Strength 2 hits, each with an AP of -1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Death Mask of Kharnutt" hidden="false" id="1217-3cb5-8758-e02d" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">The wearer of the Death Mask of Kharnutt gains the [Terror] special rule.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">The wearer of the Death Mask of Kharnutt gains the [Terror] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Icon of Rulership" hidden="false" id="a69a-798d-56a1-c611" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Models whose troop type is ‘chariot’ only. This model doubles its Unit Strength, from 3 to 6. In addition, any Impact Hits caused by this model have an Armour Piercing characteristic of -2 and the [Magical Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Models whose troop type is ‘chariot’ only. This model doubles its Unit Strength, from 3 to 6. In addition, any Impact Hits caused by this model have an Armour Piercing characteristic of -2 and the [Magical Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Scarab Brooch" hidden="false" id="5591-b93a-8206-c28b" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">When using the From Beneath the Sands special rule a summoned unit can be placed on the battlefield anywhere completely within 18’’ of a Liche Priest wearing the Scarab Brooch, rather than the usual 12’’.</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">When using the From Beneath the Sands special rule a summoned unit can be placed on the battlefield anywhere completely within 18’’ of a Liche Priest wearing the Scarab Brooch, rather than the usual 12’’.</characteristic>
       </characteristics>
     </profile>
     <profile name="Enkhil’s Kanopi" hidden="false" id="e63b-c211-56aa-dd77" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Single use. During the Command sub-phase of their turn, if they are not engaged in combat, the bearer of Enkhil’s Kanopi may attempt to unleash its contents by making a Leadership test (using their own, unmodified Leadership). If this test is passed, all ‘Remains in Play’ spells currently in play are dispelled, including spells cast by friendly Wizards.</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Single use. During the Command sub-phase of their turn, if they are not engaged in combat, the bearer of Enkhil’s Kanopi may attempt to unleash its contents by making a Leadership test (using their own, unmodified Leadership). If this test is passed, all ‘Remains in Play’ spells currently in play are dispelled, including spells cast by friendly Wizards.</characteristic>
       </characteristics>
     </profile>
     <profile name="Hieratic Jar" hidden="false" id="7ced-b473-887b-231c" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Single use. During the Command sub-phase of their turn, if they are not engaged in combat, the bearer of a Hieratic Jar can release the power held within it. The bearer may attempt to resurrect the fallen by using the [Arise!] Special rule twice during this Command sub-phase (rather than the usual once).</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Single use. During the Command sub-phase of their turn, if they are not engaged in combat, the bearer of a Hieratic Jar can release the power held within it. The bearer may attempt to resurrect the fallen by using the [Arise!] Special rule twice during this Command sub-phase (rather than the usual once).</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -142,9 +142,9 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it was charged by the enemy, a model with this special rule gains a +1 modifier to its Initiative and Attacks characteristics.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Runes of Protection" hidden="false" id="d1f1-520-9b27-c144" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Runes of Protection" hidden="false" id="d1f1-520-9b27-c144" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="24" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 6+ Ward save against any wounds suffered that were caused by a non-magical attack</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 6+ Ward save against any wounds suffered that were caused by a non-magical enemy attack.</characteristic>
       </characteristics>
     </profile>
     <profile name="Irondrake" hidden="false" id="245b-57c-3e88-450f" typeId="b070-143a-73f-2772" typeName="Model">
@@ -160,9 +160,9 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Runes of Warding" hidden="false" id="10d8-4849-8c3a-f636" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Runes of Warding" hidden="false" id="10d8-4849-8c3a-f636" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="25" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the [Flaming Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="24" publicationId="8b8d-8fc4-559e-87b1">
@@ -207,14 +207,22 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blasting Charges" hidden="false" id="c4cd-20ce-ab7a-199e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Blasting charges" hidden="false" id="c4cd-20ce-ab7a-199e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="26" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">6&quot; S3 AP-1 Armour Bane(1), Flaming Attacks, Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">6&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Drill" hidden="false" id="1394-5f7d-15ff-3370" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Steam drill" hidden="false" id="1394-5f7d-15ff-3370" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="26" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+3 AP-3 Furious Charge, Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Furious Charge, Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="8b8d-8fc4-559e-87b1">
@@ -240,9 +248,13 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-1 Breath Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile name="Brimstone Gun" hidden="false" id="aa5b-18d2-c8c0-e4d6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Brimstone gun" hidden="false" id="aa5b-18d2-c8c0-e4d6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S5 AP-2 Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">18&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="28" publicationId="8b8d-8fc4-559e-87b1">
@@ -527,9 +539,9 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When this character makes a roll To Wound, a roll of 4+ is always a success regardless of the target&apos;s Toughness. In addition, each unsaved wound inflicted by this character against an enemy model with the Warp-spawned special rule, or whose troop type is &apos;behemoth&apos; has the Multiple Wounds(D3) special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Slayer of Dragons" hidden="false" id="4351-9800-6134-8cc4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Slayer of Dragons" hidden="false" id="4351-9800-6134-8cc4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="17" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this character makes a roll To Wound, a roll of 4+ is always a success regardless of the target&apos;s Toughness. In addition, each unsaved wound inflicted by this character against an enemy model which troop type is &apos;behemoth&apos; has the Multiple Wounds(D3) special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this character makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness. In addition, each unsaved wound inflicted by this character against an enemy model whose troop type is ‘behemoth’ has the Multiple Wounds (D3) special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Artillery Master" hidden="false" id="98bd-600b-cf60-ea7f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="18" publicationId="8b8d-8fc4-559e-87b1">
@@ -542,13 +554,9 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During deployment, you may ‘Entrench’ a single non-character model whose troop type is ‘war machine’ for each character in your army with this special rule. An Entrenched war machine is considered to be behind partial cover and to be defending a low linear obstacle. Should the war machine move for any reason, it is no longer Entrenched.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Strike the Runes" hidden="false" id="25f3-44ad-a37b-a5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Strike the Runes" hidden="false" id="25f3-44ad-a37b-a5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="15" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">An Anvil of Doom can cast the following Bound spells, with a Power Level of 3:
-- Rune of Oath &amp; Steel
-- Rune of Hearth &amp; Home
-- Rune of Haste &amp; Urgency
-- Rune of Wrath &amp; Ruin</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">An Anvil of Doom can cast the following Bound spells, with a Power Level of 3:</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Calm" hidden="false" id="4c6f-86f3-37bc-e078" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
@@ -593,14 +601,22 @@ Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 or
         <characteristic name="Description" typeId="8e20-307f-c900-61b3">When making a roll to Wound with a weapon inscribed with the Master Rune of Skalf Blackhammer, a roll of 2+ is always a success, regardless of the target&apos;s Toughness.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cinderblast Bombs" hidden="false" id="edb7-2817-a45e-9e05" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Cinderblast bombs" hidden="false" id="edb7-2817-a45e-9e05" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="25" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">8&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Trollhammer Torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="191c-940d-96bf-e9e3">
+    <profile name="Trollhammer torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="191c-940d-96bf-e9e3" page="25" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">8</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Dwarf Crafted, Flaming Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Fight Me!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="3251-1b1d-cdeb-8d3e">

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -168,7 +168,7 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
     <profile name="Miner" hidden="false" id="9204-9633-f443-590f" typeId="b070-143a-73f-2772" typeName="Model">
@@ -196,22 +196,22 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Great Hammer" hidden="false" id="180a-c8b3-6ed1-5921" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-1 Armour Bane(2), Magical Attacks, Requires Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-1 Armour Bane(2), Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Brace of Drakefire Pistols" hidden="false" id="76d4-c34d-d3dd-bedd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
     <profile name="Blasting Charges" hidden="false" id="c4cd-20ce-ab7a-199e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">6&quot; S3 AP-1 Armour Bane(1), Flaming Attacks, Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">6&quot; S3 AP-1 Armour Bane(1), Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Steam Drill" hidden="false" id="1394-5f7d-15ff-3370" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+3 AP-3 Furious Charge, Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+3 AP-3 Furious Charge, Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="8b8d-8fc4-559e-87b1">
@@ -234,17 +234,17 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Steam Gun" hidden="false" id="161c-d7a-993b-854e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-1 Breath Weapon</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-1 Breath Weapon</characteristic>
       </characteristics>
     </profile>
     <profile name="Brimstone Gun" hidden="false" id="aa5b-18d2-c8c0-e4d6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S5 AP-2 Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S5 AP-2 Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Dive Bomb" hidden="false" id="37fa-95b7-5dec-19fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="28" publicationId="8b8d-8fc4-559e-87b1">
@@ -496,7 +496,7 @@ Bombing Run Table:
     </profile>
     <profile name="Oathstone" hidden="false" id="c605-51c5-a70e-ff3d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Challenges issued by a character with an Oathstone cannot be refused. In addition, a character with an Oathstone and any unit they have joined automatically passes any Panic tests they are required to make, but cannot chose to Flee as a charge reaction.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Challenges issued by a character with an Oathstone cannot be refused. In addition, a character with an Oathstone and any unit they have joined automatically passes any Panic tests they are required to make, but cannot chose to Flee as a charge reaction.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ancestral Shield" hidden="false" id="fd89-f754-8e40-4a9f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="14" publicationId="8b8d-8fc4-559e-87b1">
@@ -594,12 +594,12 @@ Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 o
     </profile>
     <profile name="Cinderblast Bombs" hidden="false" id="edb7-2817-a45e-9e05" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
     <profile name="Trollhammer Torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="191c-940d-96bf-e9e3">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
     <profile name="Fight Me!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="3251-1b1d-cdeb-8d3e">

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="1ddf-26c6-1d88-2b8c" name="Dwarfen Mountain Holds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="8" revision="29" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="1ddf-26c6-1d88-2b8c" name="Dwarfen Mountain Holds" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="8" revision="29" battleScribeVersion="2.03" type="catalogue" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedProfiles>
     <profile name="Longbeard" hidden="false" id="fbc8-de41-190b-8903" typeId="b070-143a-73f-2772" typeName="Model">
       <characteristics>
@@ -42,12 +42,12 @@
     </profile>
     <profile name="Resolute" hidden="false" id="a230-c540-6a65-4974" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule suffer a -1 modifier to the result of any Flee roll or Pursuit roll they make (to a minimum of 1).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule suffer a -1 modifier to the result of any Flee roll or Pursuit roll they make (to a minimum of 1).</characteristic>
       </characteristics>
     </profile>
     <profile name="Dwarf Crafted" hidden="false" id="b8b7-17f2-c5f-353d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Model with this special rule do not suffer the usual -1 To Hit modifier when making a [Stand &amp; Shoot] charge reaction.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not suffer the usual -1 To Hit modifier when making a Stand &amp; Shoot charge reaction.</characteristic>
       </characteristics>
     </profile>
     <profile name="Quarreller" hidden="false" id="dc45-12a3-7d3a-a293" typeId="b070-143a-73f-2772" typeName="Model">
@@ -70,9 +70,8 @@
     </profile>
     <profile name="Gromril Weapons" hidden="false" id="2e16-e293-353e-6881" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by the model with this special rule has an Armour Piercing characteristic of -1.
-
-Note that this special rule only applies to a single ordinary hand weapon. If the model is using two hand weapon or any other sort of weapon, or if their hand weapon is inscribed with any Weapon runes, this special rule ceases to apply.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by a model with this special rule has an Armour Piercing characteristic of -1.
+Note that this special rule only applies to a single, ordinary hand weapon. If the model is using two hand weapons or any other sort of weapon, or if their hand weapon is inscribed with any Weapon runes, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ironbreaker" hidden="false" id="1d0d-1cf7-9340-5a6f" typeId="b070-143a-73f-2772" typeName="Model">
@@ -90,16 +89,16 @@ Note that this special rule only applies to a single ordinary hand weapon. If th
     </profile>
     <profile name="Deathblow" hidden="false" id="233a-1715-82be-1410" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a model with this special rule is reduced to zero Wounds by an enemy attack during the Combat phase, the unit that made the attack suffers a Strength 3 hit, with an AP of -1. 
-Note that if this model is reduced to zero Wounds whilst engaged in a challenge, it is the model that made the attack that suffers this hit rather than its unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a model with this special rule is reduced to zero Wounds by an enemy attack during the Combat phase, the unit that made the attack suffers a Strength 3 hit, with an AP of -1.
+Note that if this model is reduced to zero Wounds whilst engaged in a challenge, it is the model that made the attack that suffers this hit, rather than its unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune Lore" hidden="false" id="7bfd-8005-56c0-6e77" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="39" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may be nominated to attempt a Wizardly Dispel, as if it were a Wizard. For the purposes of Wizardly Dispel attempts:
-• An Anvil of Doom counts as level 3 Wizard.
-• A Runelord counts as Level 2 Wizard.
-• A Runesmith counts as Level 1 Wizard.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may be nominated to attempt a Wizardly Dispel, as if it were a Wizard. For the purposes of Wizardly Dispel attempts:
+An Anvil of Doom counts as a level 3 Wizard
+A Runelord counts as a Level 2 Wizard
+A Runesmith counts as a Level 1 Wizard</characteristic>
       </characteristics>
     </profile>
     <profile name="Thunderer" hidden="false" id="7d93-cfa7-3653-cf2f" typeId="b070-143a-73f-2772" typeName="Model">
@@ -117,7 +116,7 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Venerable" hidden="false" id="e78f-d6ed-5364-a697" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="20" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6’’ of it can re-roll any failed Panic test.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6&quot; of it can re-roll any failed Panic test.</characteristic>
       </characteristics>
     </profile>
     <profile name="Hammerer" hidden="false" id="7a34-50ec-fd82-d932" typeId="b070-143a-73f-2772" typeName="Model">
@@ -135,12 +134,12 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Royal Guard" hidden="false" id="51a7-1a2-bff3-1d7a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="23" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include one unit of Hammerers for every King or Thane it includes. Any model in a unit of Hammerers that has been joined by a King or Thane can issue and accept challenges in the same manner as a character. Should the King or Thane leave the unit for any reason, the unit loses this ability.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army may include one unit of Hammerers for every King or Thane it includes. Any model in a unit of Hammerers that has been joined by a King or Thane can issue and accept challenges in the same manner as a character. Should the King or Thane leave the unit for any reason, the unit loses this ability.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stoic Defenders" hidden="false" id="b2ce-d68c-502b-d777" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="23" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it was charged by the enemy, a model with this special rule gains a +1 modifier to its Initiative and Attacks characteristics</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it was charged by the enemy, a model with this special rule gains a +1 modifier to its Initiative and Attacks characteristics.</characteristic>
       </characteristics>
     </profile>
     <profile name="Runes of Protection" hidden="false" id="d1f1-520-9b27-c144" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -163,12 +162,16 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Runes of Warding" hidden="false" id="10d8-4849-8c3a-f636" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the [Flaming Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the [Flaming Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="24" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">18&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Dwarf Crafted, Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Miner" hidden="false" id="9204-9633-f443-590f" typeId="b070-143a-73f-2772" typeName="Model">
@@ -186,12 +189,12 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Rune of Fear" hidden="false" id="4c19-5575-c8f7-6ed3" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Fear gains the [Fear] special rule.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Fear gains the [Fear] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Confusion" hidden="false" id="f189-f6aa-9492-8fbe" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">Any enemy unit that charges the front arc of a unit carrying a standard inscribed with the Rune of Confusion makes a disordered charge.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">Any enemy unit that charges the front arc of a unit carrying a standard inscribed with the Rune of Confusion makes a disordered charge.</characteristic>
       </characteristics>
     </profile>
     <profile name="Great Hammer" hidden="false" id="180a-c8b3-6ed1-5921" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -216,7 +219,7 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
     </profile>
     <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness.</characteristic>
       </characteristics>
     </profile>
     <profile name="Gyrocopter" hidden="false" id="bd-ec69-e76b-fdae" typeId="b070-143a-73f-2772" typeName="Model">
@@ -242,25 +245,23 @@ Note that if this model is reduced to zero Wounds whilst engaged in a challenge
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S5 AP-2 Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Dive Bomb" hidden="false" id="37fa-95b7-5dec-19fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, a unit with this special rule may perform a &apos;Dive Bomb&apos; attack against a single enemy unit that is not engaged in combat. To do so, this unit must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this unit&apos;s movement is complete, the enemy unit suffers D6 Strength 3 hits, each with an AP of -1, for each model in this unit that moved over it. However, for each roll of a natural 1 made when determining the number of hits, a bob has misfired and this unit loses a single Wound instead.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, a unit with this special rule may perform a ‘Dive Bomb’ attack against a single enemy unit that is not engaged in combat. To do so, this unit must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this unit’s movement is complete, the enemy unit suffers D6 Strength 3 hits, each with an AP of -1, for each model in this unit that moved over it. However, for each roll of a natural 1 made when determining the number of hits, a bomb has misfired and this unit loses a single Wound instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Bombing Run" hidden="false" id="e5db-41c3-532-871a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="29" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This model may perform a &apos;Bombing Run&apos; attack against a single enemy unit that is not engaged in combat. To do so, this model must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this model&apos;s movement is complete, roll on the Bombing Run table below:
-
-Bombing Run Table:
-- 1: Premature Detonation: The release mechanism jams and a bomb explodes prematurely. This model loses a single Wound.
-- 2: Duh: A solitary bomb is released, but falls to detonate before landing ????
-- 3-4: Direct Hit: a cluster of bombs lands directly on target. Place a large (5&quot;) blast template so that its central hole is directly over the centre of the enemy unit. Once placed the template will scatter D6&quot;. Any model whose base lies underneath the template&apos;s final position risks being hit and suffering a single Strength 4 hit with an AP of -1.
-- 5-6: Bomb Away: A cluster of bombs is released, falling over a wide area. Place two small (3&quot;) blast templates so that their central hole is over the enemy unit. Once placed, each template will scatter D6&quot;. Any model whose base lies underneath a template&apos;s final position risks being hit and suffering a single Strength 4 hit with an AP of -1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This model may perform a ‘Bombing Run’ attack against a single enemy unit that is not engaged in combat. To do so, this model must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this model’s movement is complete, roll on the Bombing Run table below:</characteristic>
       </characteristics>
     </profile>
     <profile name="Gyrobomber" hidden="false" id="ed4f-b75c-7abd-697b" typeId="b070-143a-73f-2772" typeName="Model">
@@ -486,12 +487,12 @@ Bombing Run Table:
     </profile>
     <profile name="Ancestral Grudge" hidden="false" id="c1e6-4b13-26b1-6f6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="12" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has the hatred Rule (enemy characters) special rule, meaning it hates all characters in the opponent army. If this character joins a unit of Longbeards or Hammerers, that unit will also gain this special rule. Should this character leave a unit of Longbeards or Hammerers they have joined for any reason, that unit loses this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has the Hatred (enemy characters) special rule, meaning it hates all characters in the opposing army. If this character joins a unit of Longbeards or Hammerers, that unit will also gain this special rule. Should this character leave a unit of Longbeards or Hammerers they have joined for any reason, that unit loses this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Borne Aloft" hidden="false" id="93e6-c161-1b92-c8af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="13" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with Shieldbearers consist of not one, but four models - the character and three loyal retainers - occupying a single base and acting together as a single entity. To represent this, a model with Shieldbearers has a split profile and follows the &apos;Split Profile (Cavalry)&apos; rule. In all other aspects this model is heavy infantry.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with Shieldbearers consists of not one, but four models – the character and three loyal retainers – occupying a single base and acting together as a single entity. To represent this, a model with Shieldbearers has a split profile and follows the ‘Split Profile (Cavalry)’ rule. In all other respects, this model is heavy infantry.</characteristic>
       </characteristics>
     </profile>
     <profile name="Oathstone" hidden="false" id="c605-51c5-a70e-ff3d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -501,7 +502,7 @@ Bombing Run Table:
     </profile>
     <profile name="Ancestral Shield" hidden="false" id="fd89-f754-8e40-4a9f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="14" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">An Anvil of Doom and the Forgefather &amp; Anvil Guards have a 5+ Ward save against any wounds suffered.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">An Anvil of Doom and the Forgefather &amp; Anvil Guard have a 5+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
     <profile name="Immovale Object" hidden="false" id="3206-e578-a350-89cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -518,7 +519,7 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
     </profile>
     <profile name="Forgefire" hidden="false" id="8acf-1a19-b087-ef76" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="16" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character joins a unit that unit will game the Armour bane (2) and Flaming Attacks special rules. Should this character leave a unit it has joined for any reasons, that unit loses this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character joins a unit, that unit will gain the Armour Bane (2) and Flaming Attacks special rules. Should this character leave a unit it has joined for any reason, that unit loses these special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Slayer of Deamons" hidden="false" id="2750-3d7-feff-371b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -533,12 +534,12 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
     </profile>
     <profile name="Artillery Master" hidden="false" id="98bd-600b-cf60-ea7f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="18" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this character is fleeing or engaged in combat, one per turn during the Shooting phase, a friendly unit of Quarrellers, unit of Thunderers or Dwarf war machine that is within its Command range can either re-roll any rolls To Hit of natural 1, or re-roll a single Artillery dice.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this character is fleeing or engaged in combat, once per turn, during the Shooting phase, a friendly unit of Quarrellers, unit of Thunderers or Dwarf war machine that is within its Command range can either re-roll any rolls To Hit of a natural 1, or re-roll a single Artillery dice.</characteristic>
       </characteristics>
     </profile>
     <profile name="Entrenchment" hidden="false" id="e87a-e45b-4129-6ba6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="18" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During deployment, you may &quot;Entrench&apos; a single non-character model whose troop type is &apos;war machine&apos; for each character in your army with this special rule. An Entrenched war machine is considered to be behind partial cover and to be defending a low linear obstacle. Should the war machine move for any reason, it is no longer Entrenched.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During deployment, you may ‘Entrench’ a single non-character model whose troop type is ‘war machine’ for each character in your army with this special rule. An Entrenched war machine is considered to be behind partial cover and to be defending a low linear obstacle. Should the war machine move for any reason, it is no longer Entrenched.</characteristic>
       </characteristics>
     </profile>
     <profile name="Strike the Runes" hidden="false" id="25f3-44ad-a37b-a5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -552,8 +553,8 @@ Note that an Anvil of Doom can still pivot freely at any time during its turn (t
     </profile>
     <profile name="Master Rune of Calm" hidden="false" id="4c6f-86f3-37bc-e078" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of the Master Rune of Calm can cast the following Bound spell, with a Power Level of 2.
-Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 or more, enemy Wizard that are within 18’’ of this model when attempting to cast a spell must increase that spell’s casting value by 2. If this Bound spell is cast with a casting value of 11 or more, enemy Wizard that are within 36’’ of this model when attempting to cast a spell must increase that spell’s casting value by 2. This spell lasts until your next Start of Turn sub-phase.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of the Master Rune of Calm can cast the following Bound spell, with a Power Level of 2.
+Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 or more, enemy Wizard that are within 18’’ of this model when attempting to cast a spell must increase that spell’s casting value by 2. If this Bound spell is cast with a casting value of 11 or more, enemy Wizard that are within 36’’ of this model when attempting to cast a spell must increase that spell’s casting value by 2. This spell lasts until your next Start of Turn sub-phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Smiting" hidden="false" id="599-5e44-7276-ba0e" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
@@ -609,208 +610,208 @@ Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 o
     </profile>
     <profile name="Master Rune of Flight" hidden="false" id="4ee7-71b5-fcaa-994c" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. Once per turn, during the Shooting phase a weapon inscribed with the Master Rune of Flight can be thrown with the following profile (which may be modified by additional runes).
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. Once per turn, during the Shooting phase a weapon inscribed with the Master Rune of Flight can be thrown with the following profile (which may be modified by additional runes).
 12&quot; S AP- [Magical Attacks], [Move &amp; Shoot], [Quick Shot]</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Parrying" hidden="false" id="427d-d38f-e232-fb0e" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Any enemy model that direct its attacks against a model wielding a weapon inscribed with a Rune of Parrying during the Combat phase suffers a -1 modifiers to its rolls to Hit.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Any enemy model that direct its attacks against a model wielding a weapon inscribed with a Rune of Parrying during the Combat phase suffers a -1 modifiers to its rolls to Hit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Alaric the Mad" hidden="false" id="1ee0-5d08-3667-44f8" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">No armour save is permitted against wounds caused by a weapon inscribed with the Master Rune of Alaric the Mad (Ward and Regeneration saves can be attempted as normal).</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">No armour save is permitted against wounds caused by a weapon inscribed with the Master Rune of Alaric the Mad (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Speed" hidden="false" id="36ff-8e58-2a49-556b" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. For each Rune of Speed inscribed upon a weapon, its wielder has a +1 modifier to their Initiative Skill characteristic.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. For each Rune of Speed inscribed upon a weapon, its wielder has a +1 modifier to their Initiative Skill characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Cleaving" hidden="false" id="3830-a52c-c08-5677" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. For each Rune of Cleaving inscribed upon a weapon, its Armour Piercing characteristic is improved by 1.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Hand weapon only. For each Rune of Cleaving inscribed upon a weapon, its Armour Piercing characteristic is improved by 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Might" hidden="false" id="11a5-807e-1920-8e95" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Might inscribed upon a weapon, its wielder has a +1 modifier to their Strength characteristic.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Might inscribed upon a weapon, its wielder has a +1 modifier to their Strength characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Grudge Rune" hidden="false" id="34c9-6f88-dcfd-d3fa" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Grudge Rune inscribed upon a weapon, its wielder may re-roll a single roll To Hit of a natural 1 made during the Combat phase.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Grudge Rune inscribed upon a weapon, its wielder may re-roll a single roll To Hit of a natural 1 made during the Combat phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Fury" hidden="false" id="ea58-1a09-e839-cced" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Fury inscribed upon a weapon, its wielder has a +1 modifier to their Attacks characteristic.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Fury inscribed upon a weapon, its wielder has a +1 modifier to their Attacks characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Banishment" hidden="false" id="db94-6922-a4dd-95ec" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Enemy models with the [Warp-spawned] special rule cannot make any Ward saves against hit caused by a weapon inscribed with a Rune of Banishment.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Enemy models with the [Warp-spawned] special rule cannot make any Ward saves against hit caused by a weapon inscribed with a Rune of Banishment.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Breaking" hidden="false" id="1e54-2c90-c0cb-beef" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Any magic weapon carried by an enemy model that suffers one or more unsaved wounds from a weapon inscribed with the Master Rune of Breaking is destroyed and cannot be used for the remainder of the game. Note that even if their magic weapon is destroyed, the model is still considered to be armed with a hand weapon.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">Any magic weapon carried by an enemy model that suffers one or more unsaved wounds from a weapon inscribed with the Master Rune of Breaking is destroyed and cannot be used for the remainder of the game. Note that even if their magic weapon is destroyed, the model is still considered to be armed with a hand weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Swiftness" hidden="false" id="1ddc-1ba5-1431-cf53" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">The wielder of weapon inscribed with the Master Rune of Swiftness gains the [Strike First] special rule.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">The wielder of weapon inscribed with the Master Rune of Swiftness gains the [Strike First] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Dragon Slaying" hidden="false" id="a44f-dc0d-9ba1-79b6" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">When making a roll To Wound against an enemy whose troop type is ’behemoth’ with a weapon inscribed with the Master Rune of Dragon Slaying, a roll of 2+ is always a success, regardless of the target Toughness.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">When making a roll To Wound against an enemy whose troop type is ’behemoth’ with a weapon inscribed with the Master Rune of Dragon Slaying, a roll of 2+ is always a success, regardless of the target Toughness.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Fire" hidden="false" id="6dc-ed7-573-e1ca" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">The wielder of a weapon inscribed with a Rune of Fire gains the [Flaming Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">The wielder of a weapon inscribed with a Rune of Fire gains the [Flaming Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Striking" hidden="false" id="c8f2-d8c4-bd32-7573" typeId="a981-4ba6-83fd-3044" typeName="Weapon Runes">
       <characteristics>
-        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Striking inscribed upon a weapon, its wielder has a +1 modifier to their Weapon Skill characteristic.</characteristic>
+        <characteristic name="Description" typeId="8e20-307f-c900-61b3">For each Rune of Striking inscribed upon a weapon, its wielder has a +1 modifier to their Weapon Skill characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Adamant" hidden="false" id="4a80-633b-7ad6-e3a3" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with the Master Rune of Adamant has a Toughness characteristic of 10. This rune cannot be combined with any other Armour runes.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with the Master Rune of Adamant has a Toughness characteristic of 10. This rune cannot be combined with any other Armour runes.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Gromril" hidden="false" id="d7c2-7286-62de-65cf" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with the Master Rune of Gromril has an armour value of 2+, which cannot be improved in any way.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with the Master Rune of Gromril has an armour value of 2+, which cannot be improved in any way.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Iron" hidden="false" id="2dad-c158-2e0a-bb44" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a Rune of Iron hat +1 Wound on its profile.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a Rune of Iron hat +1 Wound on its profile.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Fortitude" hidden="false" id="b891-ab45-402a-1381" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">For each Rune of Fortitude inscribed upon their amour, a model has +1 modifier to its Toughness characteristic (to a maximum of 10).</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">For each Rune of Fortitude inscribed upon their amour, a model has +1 modifier to its Toughness characteristic (to a maximum of 10).</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Shielding" hidden="false" id="67a1-4af7-7fa2-bf13" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a single Rune of Shielding has a 6+ Ward save against any wounds suffered. For each additional Rune of Shielding, this Ward save is improved by 1.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a single Rune of Shielding has a 6+ Ward save against any wounds suffered. For each additional Rune of Shielding, this Ward save is improved by 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Stone" hidden="false" id="dc0-60ad-23a9-43f" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">Single use. For each Rune of Stone inscribed upon their armour, a model may re-roll a single failed Armour Save roll.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">Single use. For each Rune of Stone inscribed upon their armour, a model may re-roll a single failed Armour Save roll.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Preservation" hidden="false" id="4603-e11e-aba0-eee8" typeId="c5ef-cad7-9aee-7302" typeName="Armour Runes">
       <characteristics>
-        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a Rune of Preservation is immune to both the [Killing Blow] and [Multiple Wound (X)] special rules. If the wearer suffers an unsaved wound from an attack with either of these special rules, they lose a single Wound.</characteristic>
+        <characteristic name="Description" typeId="ca93-7d2c-11a-3762">A model wearing armour inscribed with a Rune of Preservation is immune to both the [Killing Blow] and [Multiple Wound (X)] special rules. If the wearer suffers an unsaved wound from an attack with either of these special rules, they lose a single Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Passage" hidden="false" id="3d3-10db-8e58-1625" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of a Rune of Passage gains the [Move Through Cover] special rule. Any unit joined by the bearer also gains the [Move Through Cover] special rule. Should the bearer leave the unit for any reason, the unit loses this special rule.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of a Rune of Passage gains the [Move Through Cover] special rule. Any unit joined by the bearer also gains the [Move Through Cover] special rule. Should the bearer leave the unit for any reason, the unit loses this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of the Furnace" hidden="false" id="6536-9a71-388a-2cee" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of a Rune of the Furnace has a 3+ Ward save against any wounds suffered that were caused by an attack that has the [Flaming Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">The bearer of a Rune of the Furnace has a 3+ Ward save against any wounds suffered that were caused by an attack that has the [Flaming Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Luck" hidden="false" id="b9d-519b-9abb-fec9" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Single use. The bearer of a Rune of Luck may use it to re-roll a single failed roll To Hit or To Wound, or re-roll a single failed Armour Save roll.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Single use. The bearer of a Rune of Luck may use it to re-roll a single failed roll To Hit or To Wound, or re-roll a single failed Armour Save roll.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Warding" hidden="false" id="2f32-75fc-bb37-9cec" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Single use. Each Rune of Warding gives its bearer a 2+ Ward save against a single wound.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Single use. Each Rune of Warding gives its bearer a 2+ Ward save against a single wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Spellbreaking" hidden="false" id="6a2b-5c66-6d76-ba17" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Anvil of Doom and Dwarf Runesmiths only. Single use. The bearer of a Rune of Spellbreaking may use it instead of making a dispel attempt. If they do so, the spell is automatically dispelled with no Dispel roll required.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Anvil of Doom and Dwarf Runesmiths only. Single use. The bearer of a Rune of Spellbreaking may use it instead of making a dispel attempt. If they do so, the spell is automatically dispelled with no Dispel roll required.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Spite" hidden="false" id="f2d6-7aed-8add-7a33" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Each time the bearer of the Master Rune of Spite loses a Wound to an enemy attack, during the Combat phase, the unit that made the attack suffers a Strength 5 hit with an AP of -2</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Each time the bearer of the Master Rune of Spite loses a Wound to an enemy attack, during the Combat phase, the unit that made the attack suffers a Strength 5 hit with an AP of -2</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Balance" hidden="false" id="5b46-bd4e-d356-ccb6" typeId="d839-c07a-fdb2-5492" typeName="Talismanic Runes">
       <characteristics>
-        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Anvil of Doom and Dwarf Runesmiths only. Once per turn, the bearer of the Master Rune of Balance may use it when attempting a Wizardly dispel. If they do so, roll an extra D6 when making the Dispel roll and discard the lowest results.</characteristic>
+        <characteristic name="Description" typeId="7145-6b91-ed0d-f17a">Anvil of Doom and Dwarf Runesmiths only. Once per turn, the bearer of the Master Rune of Balance may use it when attempting a Wizardly dispel. If they do so, roll an extra D6 when making the Dispel roll and discard the lowest results.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Grungni" hidden="false" id="2d01-95e2-bb37-11f3" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">Battle Standard Bearer only. A unit carrying a standard inscribed with the master Rune of Grungni has a 5+ Ward save against any wounds suffered. In addition, whilst within 6’’ of the model carrying this standard, friendly units have a 6+ Ward save against any wounds suffered during the Shooting phase.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">Battle Standard Bearer only. A unit carrying a standard inscribed with the master Rune of Grungni has a 5+ Ward save against any wounds suffered. In addition, whilst within 6’’ of the model carrying this standard, friendly units have a 6+ Ward save against any wounds suffered during the Shooting phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Stromni Redbeard" hidden="false" id="4a9d-8de1-8e04-ad23" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">When calculating its combat result, any friendly unit within the Command range of the model carrying the standard inscribed with the master Rune of Stromni Redbeard may claim an additional bonus of +1 combat result point.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">When calculating its combat result, any friendly unit within the Command range of the model carrying the standard inscribed with the master Rune of Stromni Redbeard may claim an additional bonus of +1 combat result point.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Hesitation" hidden="false" id="bf2a-3583-6fd3-24bf" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">An enemy unit that charges the front arc of a unit carrying a standard inscribed with the Rune of Hesitation does not count as having charged for the purposes of choosing which weapon to use or using any special rules it may have. Note that the unit carrying this rune still counts as having been charged by the enemy unit</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">An enemy unit that charges the front arc of a unit carrying a standard inscribed with the Rune of Hesitation does not count as having charged for the purposes of choosing which weapon to use or using any special rules it may have. Note that the unit carrying this rune still counts as having been charged by the enemy unit</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Battle" hidden="false" id="2ba0-efe5-1531-82dc" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">When calculating its combat result, a unit carrying a standard inscribed with the Rune of Battle may claim an additional bonus of +1 combat result point</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">When calculating its combat result, a unit carrying a standard inscribed with the Rune of Battle may claim an additional bonus of +1 combat result point</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Courage" hidden="false" id="249a-c762-2c5e-ea12" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Courage automatically passes any [Fear] or [Terror] tests it is required to make.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Courage automatically passes any [Fear] or [Terror] tests it is required to make.</characteristic>
       </characteristics>
     </profile>
     <profile name="Strollaz’ Rune" hidden="false" id="13b2-1bd2-c2e9-6021" typeId="9c4f-4e8-f3bf-3908" typeName="Standard Runes">
       <characteristics>
-        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Strollaz’ gains the Vanguard special rule.</characteristic>
+        <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">A unit carrying a standard inscribed with the Rune of Strollaz’ gains the Vanguard special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Immolation" hidden="false" id="2e66-d242-c5e1-9e2f" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Cannon only. Single use. If a cannon inscribed with the Master Rune of Immolation loses its last Wound to an enemy attack during the Combat phase, it may be exploded by its crew. Every enemy unit in base contact with this model suffers D6 Strength 5 hits with an AP of -2. The cannon is then removed from play as a casualty.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Cannon only. Single use. If a cannon inscribed with the Master Rune of Immolation loses its last Wound to an enemy attack during the Combat phase, it may be exploded by its crew. Every enemy unit in base contact with this model suffers D6 Strength 5 hits with an AP of -2. The cannon is then removed from play as a casualty.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Rune of Disguise" hidden="false" id="c27c-bf1f-cc21-e5f0" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with the Master Rune of Disguise is always considered to be behind full cover.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with the Master Rune of Disguise is always considered to be behind full cover.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Skewering" hidden="false" id="fa43-c724-f7d3-9f4e" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Bolt throwers only. A bolt thrower inscribed with this rune has a +1 modifier to its Strength characteristic. In addition no armour save is permitted against wounds caused by a bolt thrower inscribed with a Rune of Skewering (Ward and [Regeneration] saves can be attempted as normal).</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Bolt throwers only. A bolt thrower inscribed with this rune has a +1 modifier to its Strength characteristic. In addition no armour save is permitted against wounds caused by a bolt thrower inscribed with a Rune of Skewering (Ward and [Regeneration] saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Stalwart Rune" hidden="false" id="a549-aea2-ca0-86a8" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">When calculating its combat result, a war machine inscribed with a Stalwart Rune may claim a bonus of +1 combat result point.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">When calculating its combat result, a war machine inscribed with a Stalwart Rune may claim a bonus of +1 combat result point.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Reloading" hidden="false" id="89be-dab7-6cb8-abbf" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with a Rune of Reloading can shoot every turn, even if it misfired and malfunctioned during its previous turn.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with a Rune of Reloading can shoot every turn, even if it misfired and malfunctioned during its previous turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Burning" hidden="false" id="8fcb-b32c-4f84-5358" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with a Rune of Burning gains the [Flaming Attacks] special rule.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">A war machine inscribed with a Rune of Burning gains the [Flaming Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rune of Forging" hidden="false" id="7ab6-d92f-7f3-816" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">
       <characteristics>
-        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Single use. A war machine inscribed with a Rune of Forging may use it to re-roll a single misfire on the Artillery dice.</characteristic>
+        <characteristic name="Description" typeId="b43f-5dcb-c595-3518">Single use. A war machine inscribed with a Rune of Forging may use it to re-roll a single misfire on the Artillery dice.</characteristic>
       </characteristics>
     </profile>
     <profile name="Test Engineer Rune" hidden="false" id="3818-2272-6b15-2ea9" typeId="1259-b3c-4179-7c40" typeName="Engineering Runes">

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -223,6 +223,7 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+3</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Furious Charge, Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A unit of Miners held in reserve that includes a Prospector equipped with a steam drill may re-roll the D6 when rolling to determine if they arrive on the battlefield.</characteristic>
       </characteristics>
     </profile>
     <profile name="Slayer" hidden="false" id="ea84-d53c-ef3b-57e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="8b8d-8fc4-559e-87b1">
@@ -608,6 +609,7 @@ Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 or
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Flaming Attacks, Quick Shot</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A unit hit by a cinderblast bomb suffers D6+1 hits (rather than the usual one).</characteristic>
       </characteristics>
     </profile>
     <profile name="Trollhammer torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="191c-940d-96bf-e9e3" page="25" publicationId="8b8d-8fc4-559e-87b1">

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -82,6 +82,7 @@ Note that this special rule only applies to a single, non-magical hand weapon an
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A model wielding a ceremonial halberd cannot make a supporting attack during a turn in which it charged.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dragon fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="174" publicationId="8b8d-8fc4-559e-87b1">

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -18,7 +18,8 @@
     </profile>
     <profile name="Dragon Armour" hidden="false" id="f1fc-eaed-78ef-bc1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="184" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered. In addition a Wizard with this special rule may wear armour without penalty.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered. In addition, a Wizard with this special rule may wear armour without penalty.
+On the following pages you will find a full description for each of the army special rules used by models drawn from the High Elf Realms army list:</characteristic>
       </characteristics>
     </profile>
     <profile name="Elven Reflexes" hidden="false" id="f18f-50f-3108-1486" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -38,9 +39,8 @@
     </profile>
     <profile name="Ithilmar Weapons" hidden="false" id="ff10-6f2b-b0a4-9a1a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When engaged in combat, a model with this special rule that in fighting with a hand weapon may re-roll any rolls To Hit of a natural 1.
-
-Note that this special rule only applies to single non-magical hand weapons and does not apply if a model&apos;s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When engaged in combat, a model with this special rule that is fighting with a hand weapon may re-roll any rolls To Hit of a natural 1.
+Note that this special rule only applies to a single, non-magical hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chracian Great Blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -63,9 +63,13 @@ Note that this special rule only applies to single non-magical hand weapons and 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst in base contact with this model, enemy models become subject to the Strike Last special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bow of Avelorn" hidden="false" id="e42c-4a2f-b084-91c0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Bow of Avelorn" hidden="false" id="e42c-4a2f-b084-91c0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 Armour Bane (1), Magica Attacks, Volley Fire</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">30&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Magical Attacks, Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Ceremonial Halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -119,9 +123,13 @@ Note that this special rule only applies to single non-magical hand weapons and 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any bow (longbow, shortbow, warbow or Bow of Averlorn) carried by a model with this special rule has the Armour Bane (1) special rule and Armor Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 magical Attacks, Requires Two Hands</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Horn of Isha" hidden="false" id="5439-9814-3c7c-1f06" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -131,15 +139,13 @@ Note that this special rule only applies to single non-magical hand weapons and 
     </profile>
     <profile name="Naval Discipline" hidden="false" id="ca28-8a3-989a-4ecc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="162" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit of Lothern Sea Guard may use this special rule when it makes a Stand &amp; Shoot charge reaction. A unit that does it can make a Stand &amp; Shoot charge reaction regardless of how close the charging unit is. Once this shooting has been resolved, the charged unit may make a free redraw the ranks manoeuvre, after which it will Hold until moved the charging unit.
-
-
-Units that are fleeing, that are already engaged in combat when charged, or that has been joined by a character that dos not have this special rule, cannot use this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit of Lothern Sea Guard may use this special rule when it makes a Stand &amp; Shoot charge reaction. A unit that does so can make a Stand &amp; Shoot charge reaction regardless of how close the charging unit is. Once this shooting has been resolved, the charged unit may make a free redress the ranks manoeuvre, after which it will Hold and await the charging unit.
+Units that are fleeing, that are already engaged in combat when charged, or that have been joined by a character that does not have this special rule cannot use this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chracian Warriors" hidden="false" id="2b64-4e75-6d83-19df" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="163" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by your army&apos;s general or by a character with the Chracian Hunter Elven Honor.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by your army’s General, or by a character with the Chracian Hunter Elven Honour.</characteristic>
       </characteristics>
     </profile>
     <profile name="King&apos;s Guard" hidden="false" id="6c87-1ec1-954d-919b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -154,7 +160,7 @@ Units that are fleeing, that are already engaged in combat when charged, or that
     </profile>
     <profile name="Deflect Shots" hidden="false" id="42b9-dd12-7ae9-b1ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="164" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered that were caused by a non magical shooting attack.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered that were caused by a non-magical shooting attack.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warriors of the White Tower" hidden="false" id="d49f-735d-777d-f8d2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -686,7 +692,7 @@ Units that are fleeing, that are already engaged in combat when charged, or that
     </profile>
     <profile name="Lore of Saphery" hidden="false" id="ab46-ca53-931e-a0e1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the &apos;Lore of Saphery&apos; special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead the signature spell of their chose Lore of Magic, or one of the following spells: 
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the &apos;Lore of Saphery&apos; special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead the signature spell of their chose Lore of Magic, or one of the following spells: 
 - Hand of Khaine
 - Courage of Aenarion
 - Vaul&apos;s Unmaking</characteristic>
@@ -696,11 +702,11 @@ Units that are fleeing, that are already engaged in combat when charged, or that
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">High Elf Lords only. A character with the Loremaster Elven Honour:
 -Cannot be mounted
-- Is a Level 1 Wizard and knows one randomly generated spell from one of the following Lores of Magic: 
-   Battle Magic
-   Elementalism
-   High Magic
-   Illusion
+- Is a Level 1 Wizard and knows one randomly generated spell from one of the following Lores of Magic: 
+   Battle Magic
+   Elementalism
+   High Magic
+   Illusion
 - May be equipped with a Sword of Hoeth for no additional points. If so, they may not takeany additional, non-magical weapons.
 - Gains the Ithlmar Armour, Lileath´s Blessing and Lore of Saphery special rules.</characteristic>
       </characteristics>

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -45,7 +45,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
     </profile>
     <profile name="Chracian Great Blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike last</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike last</characteristic>
       </characteristics>
     </profile>
     <profile name="Lion Cloak" hidden="false" id="4123-3227-347e-3b39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
@@ -65,17 +65,17 @@ Note that this special rule only applies to single non-magical hand weapons and 
     </profile>
     <profile name="Bow of Avelorn" hidden="false" id="e42c-4a2f-b084-91c0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 Armour Bane (1), Magica Attacks, Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 Armour Bane (1), Magica Attacks, Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Ceremonial Halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands. A model wielding a ceremonial halberd cannot make a supporting attack during a turn in which it charged..</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands. A model wielding a ceremonial halberd cannot make a supporting attack during a turn in which it charged..</characteristic>
       </characteristics>
     </profile>
     <profile name="Dragon Fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Barded Elven Steed" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="eb80-a1fe-816f-ca9f">
@@ -106,12 +106,12 @@ Note that this special rule only applies to single non-magical hand weapons and 
     </profile>
     <profile name="Handmaiden&apos;s Spear" hidden="false" id="cb8b-78-2f65-59c3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5 AP-1 During a turn in which it was charged, a model wielding a Handmaiden&apos;s spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S5 AP-1 During a turn in which it was charged, a model wielding a Handmaiden&apos;s spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
       </characteristics>
     </profile>
     <profile name="Eagle-Eye Bolt Thrower" hidden="false" id="6ff2-57b7-2d12-a850" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-3 Cumbersome, Multiple Wounds(D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-3 Cumbersome, Multiple Wounds(D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Arrows of Isha" hidden="false" id="d326-aa58-9de8-39d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -121,7 +121,7 @@ Note that this special rule only applies to single non-magical hand weapons and 
     </profile>
     <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 magical Attacks, Requires Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Horn of Isha" hidden="false" id="5439-9814-3c7c-1f06" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="56fb-835b-a377-6639" name="High Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="15" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
-    <profile name="Sons of Caledor" hidden="false" id="2f86-a9f-38aa-d39a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Sons of Caledor" hidden="false" id="2f86-a9f-38aa-d39a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by your army&apos;s General or by a character with the Blood of Caledor Elven Honour.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by your army’s General, or by a character with the Blood of Caledor Elven Honour.</characteristic>
       </characteristics>
     </profile>
     <profile name="Lileath&apos;s Blessing" hidden="false" id="a7af-d5ea-928a-6134" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -11,15 +11,14 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, a model with this special rule may re-roll a single failed Casting roll.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blessings of Asuryan" hidden="false" id="64df-8822-caec-91e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Blessings of Asuryan" hidden="false" id="64df-8822-caec-91e8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="184" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dragon Armour" hidden="false" id="f1fc-eaed-78ef-bc1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="184" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered. In addition, a Wizard with this special rule may wear armour without penalty.
-On the following pages you will find a full description for each of the army special rules used by models drawn from the High Elf Realms army list:</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered. In addition, a Wizard with this special rule may wear armour without penalty.</characteristic>
       </characteristics>
     </profile>
     <profile name="Elven Reflexes" hidden="false" id="f18f-50f-3108-1486" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -43,9 +42,13 @@ On the following pages you will find a full description for each of the army spe
 Note that this special rule only applies to a single, non-magical hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Chracian Great Blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Chracian great blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike last</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Lion Cloak" hidden="false" id="4123-3227-347e-3b39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
@@ -72,14 +75,22 @@ Note that this special rule only applies to a single, non-magical hand weapon an
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Magical Attacks, Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ceremonial Halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Ceremonial halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands. A model wielding a ceremonial halberd cannot make a supporting attack during a turn in which it charged..</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dragon Fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Dragon fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="174" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Barded Elven Steed" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="eb80-a1fe-816f-ca9f">
@@ -113,14 +124,18 @@ Note that this special rule only applies to a single, non-magical hand weapon an
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S5 AP-1 During a turn in which it was charged, a model wielding a Handmaiden&apos;s spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Eagle-Eye Bolt Thrower" hidden="false" id="6ff2-57b7-2d12-a850" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Eagle-eye bolt thrower" hidden="false" id="6ff2-57b7-2d12-a850" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="172" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-3 Cumbersome, Multiple Wounds(D3)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Arrows of Isha" hidden="false" id="d326-aa58-9de8-39d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Arrows of Isha" hidden="false" id="d326-aa58-9de8-39d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="184" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any bow (longbow, shortbow, warbow or Bow of Averlorn) carried by a model with this special rule has the Armour Bane (1) special rule and Armor Piercing characteristic of -1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any bow (longbow, shortbow, warbow or Bow of Avelorn) carried by a model with this special rule has the Armour Bane (1) special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
@@ -132,9 +147,9 @@ Note that this special rule only applies to a single, non-magical hand weapon an
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Horn of Isha" hidden="false" id="5439-9814-3c7c-1f06" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Horn of Isha" hidden="false" id="5439-9814-3c7c-1f06" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="159" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Single use. During a Command sub-phase of their turn, this character may attempt to use the Horn of Isha by making a Leadershiop test (using their own Leadership). If the test is passed, until your next Start of Turn sub-phase, this character and any unit they have joined gain a +1 modifier to both their To Hit and their rolls To Wound.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Single use. During the Command sub-phase of their turn, this character may attempt to use the Horn of Isha by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase, this character and any unit they have joined gain a +1 modifier to both their rolls To Hit and their rolls To Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Naval Discipline" hidden="false" id="ca28-8a3-989a-4ecc" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="162" publicationId="8b8d-8fc4-559e-87b1">
@@ -163,37 +178,37 @@ Units that are fleeing, that are already engaged in combat when charged, or that
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 6+ Ward save against any wounds suffered that were caused by a non-magical shooting attack.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warriors of the White Tower" hidden="false" id="d49f-735d-777d-f8d2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Warriors of the White Tower" hidden="false" id="d49f-735d-777d-f8d2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="164" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by a High Elf mage or by a character with either the Warden of Saphery or Loremaster Elven Honours.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by a High Elf Mage, or by a character with either the Warden of Saphery or Loremaster Elven Honour.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Witness to Destiny" hidden="false" id="acf9-cde8-e83c-c583" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Witness to Destiny" hidden="false" id="acf9-cde8-e83c-c583" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="165" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 6+ Ward save against any wounds suffered that were caused by a non-magical enemy attack.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warriors of Nagarythe" hidden="false" id="93a1-6428-8825-b7e7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Warriors of Nagarythe" hidden="false" id="93a1-6428-8825-b7e7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may only be joined by a character with the Shadow Stalker Elven Honour.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Valour of Ages" hidden="false" id="6731-240-f75b-dcac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Valour of Ages" hidden="false" id="6731-240-f75b-dcac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="185" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may re-roll any failed Panic tests caused by taking heavy casualties on by being fled though by a friendly unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may re-roll any failed Panic test caused by taking heavy casualties or by being fled through by a friendly unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="From the Ashes" hidden="false" id="751f-b2e3-fa87-334e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="From the Ashes" hidden="false" id="751f-b2e3-fa87-334e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">When a Flamespyre Phoenix loses its last Wound, roll a D6 before removing the model from play:
-- On a roll of 1-2 the Phoenix crumbles into cold ashes and is removed from play.
-- On a roll of 3-5 the Phoenix explodes into flames. Every enemy unit in base contact with it suffers D6 Strength 3 hits, each with and AP of -1 and the Flaming Attacks special rule. Once these hits are resolved, this model is removed from play.
-- On a roll of 6, the Phoenix (and its rider, should it have one) are briefly consumed in a ball of flames, and are immediately reborn, recovering D3 wounds.</characteristic>
+•	On a roll of 1-2, the Phoenix crumbles into cold ashes and is removed from play.
+•	On a roll of 3-5, the Phoenix explodes into flame. Every enemy unit in base contact with it suffers D6 Strength 3 hits, each with an AP of -1 and the Flaming Attacks special rule. Once these hits are resolved, this model is removed from play.
+•	On a roll of 6, the Phoenix (and its rider, should it have one) are briefly consumed in a ball of flames, and are immediately reborn, recovering D3 Wounds.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wake of Fire" hidden="false" id="3cc3-f9c9-4679-c08e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Wake of Fire" hidden="false" id="3cc3-f9c9-4679-c08e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This model may perform a &apos;Wake of Fire&apos; attack against a single enemy unit that is not engaged in combat. To do so, this model must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this model&apos;s movement is complete, the enemy unit suffers D6 Strength hits, each with and AP of -1 and with the Flaming Attacks special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This model may perform a ‘Wake of Fire’ attack against a single enemy unit that is not engaged in combat. To do so, this model must move (by flying) over the unit it wishes to attack during the Remaining Moves sub-phase. Once this model’s movement is complete, the enemy unit suffers D6 Strength 4 hits, each with an AP of -1 and with the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Noble" hidden="false" id="c489-7c8c-6894-31b1" typeId="b070-143a-73f-2772" typeName="Model">

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -4388,7 +4388,7 @@
     </profile>
     <profile name="Troll Vomit" hidden="false" id="cdde-5994-8941-787f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S 3 AP2</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S 3 AP2</characteristic>
       </characteristics>
     </profile>
     <profile name="Giant Attacks" hidden="false" id="bcfc-491-b8db-51c8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -4904,7 +4904,7 @@
     </profile>
     <profile name="Giant Club" hidden="false" id="600e-c97a-3c61-9f5b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">A Giant&apos;s club may have different characteristics and special rules depending upon what they do with it, as described in the [Giant Attacks] special rule.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">A Giant&apos;s club may have different characteristics and special rules depending upon what they do with it, as described in the [Giant Attacks] special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Wyvern" hidden="false" id="7201-2362-dd8b-8cf4" typeId="b070-143a-73f-2772" typeName="Model">
@@ -4999,12 +4999,12 @@
     </profile>
     <profile name="Spidersilk Lobber" hidden="false" id="1feb-b4ec-6cfc-8f7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [12-48&quot; S2(4) AP-(-1) [Bombardment], [Cumbersome] This weapon shoots like a stone thrower, using the [Bombardment] special rule and a 5&quot; blast template. If a &apos;Misfire&apos; is rolled on the Artillery dice, this model loses a single Wound (instead of rolling on a Misfire table).</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [12-48&quot; S2(4) AP-(-1) [Bombardment], [Cumbersome] This weapon shoots like a stone thrower, using the [Bombardment] special rule and a 5&quot; blast template. If a &apos;Misfire&apos; is rolled on the Artillery dice, this model loses a single Wound (instead of rolling on a Misfire table).</characteristic>
       </characteristics>
     </profile>
     <profile name="Venom Surge" hidden="false" id="d4a3-bdc8-bdad-bb9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [Multiple Wounds (D6)], [Poisoned Attacks], [Strike First]. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [Multiple Wounds (D6)], [Poisoned Attacks], [Strike First]. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Release the Fanatics!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="70d3-ea31-eb40-a58c">
@@ -5027,7 +5027,7 @@
     </profile>
     <profile name="Fanatic Ball &amp; Chain" hidden="false" id="1f92-933c-dfaa-bd0a" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Any unit (friend ofr foe) that is moved through by a moving Fanatic, or that moves through a Fanatic, suffers D6 Strength 5 hits, each with an AP of -3.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Any unit (friend ofr foe) that is moved through by a moving Fanatic, or that moves through a Fanatic, suffers D6 Strength 5 hits, each with an AP of -3.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mangler Squigs" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="90dd-6117-857f-1a73">
@@ -5063,7 +5063,7 @@
     </profile>
     <profile name="Huge Gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-1 [Armour Bane (1)]</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1 [Armour Bane (1)]</characteristic>
       </characteristics>
     </profile>
     <profile name="Arachnok Spider" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="9a7a-fe6a-aeab-f49a">
@@ -5086,7 +5086,7 @@
     </profile>
     <profile name="Colossal Gang-Filled Gob" hidden="false" id="fc81-c5b4-c632-2a80" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Ap-2 [Killing Blow]</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Ap-2 [Killing Blow]</characteristic>
       </characteristics>
     </profile>
     <profile name="Spiked Ball &amp; Chains" hidden="false" id="8188-5c79-c398-cc4b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -4295,8 +4295,7 @@ Note that this special rule only applies to non-magical weapons and does not app
     <profile name="Ignore Goblin Panic" hidden="false" id="78e4-fffe-6662-41fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make a Panic test when a friendly Goblin unit is destroyed or Breaks and flees from combat whilst within 6&quot; of it. Nor does this unit have to make a Panic test when it is fled through by a friendly Goblin unit.
-Note that, for the purposes of this rule, a Goblin unit is considered to be any unit that is made up entirely of Goblins of any kind, mounted or otherwise. This includes any war machine or chariot that is crewed entirely by Goblins. Should a Goblin unit be joined by an Orc character, it is no longer considered to be a Goblin unit.
-On the following pages you will find a full description for each of the army special rules used by models drawn from the Orc &amp; Goblin Tribes army list:</characteristic>
+Note that, for the purposes of this rule, a Goblin unit is considered to be any unit that is made up entirely of Goblins of any kind, mounted or otherwise. This includes any war machine or chariot that is crewed entirely by Goblins. Should a Goblin unit be joined by an Orc character, it is no longer considered to be a Goblin unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ignore Panic" hidden="false" id="a097-2e5c-8366-efc1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
@@ -5011,9 +5010,13 @@ Note that, for the purposes of this rule, a unit of Orcs is considered to be any
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [12-48&quot; S2(4) AP-(-1) [Bombardment], [Cumbersome] This weapon shoots like a stone thrower, using the [Bombardment] special rule and a 5&quot; blast template. If a &apos;Misfire&apos; is rolled on the Artillery dice, this model loses a single Wound (instead of rolling on a Misfire table).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Venom Surge" hidden="false" id="d4a3-bdc8-bdad-bb9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Venom surge" hidden="false" id="d4a3-bdc8-bdad-bb9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="36" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [Multiple Wounds (D6)], [Poisoned Attacks], [Strike First]. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Wounds (D6), Poisoned Attacks, Strike First</characteristic>
       </characteristics>
     </profile>
     <profile name="Release the Fanatics!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="70d3-ea31-eb40-a58c" page="26" publicationId="7c89-736c-3139-24a0">
@@ -5076,9 +5079,13 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Squig Herd ever Break and flee from combat, the Cave Squigs will go wild. If the Squig Herd contains five or more Cave Squigs, every unit (friend or foe) within 2D6&quot; of it suffers D3 Strength 5 hits, each with an AP of -1. For every additional five Cave Squigs the Squig Herd contains, apply a +1 modifier to the D3. Once these hits have been resolved, treat the unit as having been completely destroyed in combat and remove it from play.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Huge Gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Huge gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="32" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1 [Armour Bane (1)]</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Arachnok Spider" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="9a7a-fe6a-aeab-f49a">
@@ -5094,9 +5101,9 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ker-Splat" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c39a-77fc-8434-52a2">
+    <profile name="Ker-Splat" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c39a-77fc-8434-52a2" page="37" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Mangle Squigs treat all difficult terrain as dangerous terrain.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Mangler Squigs treat all difficult terrain as dangerous terrain.</characteristic>
       </characteristics>
     </profile>
     <profile name="Colossal Gang-Filled Gob" hidden="false" id="fc81-c5b4-c632-2a80" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -5017,6 +5017,7 @@ Note that, for the purposes of this rule, a unit of Orcs is considered to be any
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Wounds (D6), Poisoned Attacks, Strike First</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Release the Fanatics!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="70d3-ea31-eb40-a58c" page="26" publicationId="7c89-736c-3139-24a0">

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="18" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="18" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Orc Mobs" hidden="false" id="51e8-1471-ce4c-d5dd">
       <categoryLinks>
@@ -4271,7 +4271,8 @@
   <sharedProfiles>
     <profile name="Choppas" hidden="false" id="b592-330-5a29-162f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, a model with this special rule may re-roll any rolls To Wound on natural 1 and improves the Armour Piercing characteristic of its weapons by 1</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, a model with this special rule may re-roll any rolls To Wound of a natural 1, and improves the Armour Piercing characteristic of its weapon(s) by 1.
+Note that this special rule only applies to non-magical weapons and does not apply to a model’s mount (should it have one). If the model is using a magic weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
     <profile name="Big &apos;Uns" hidden="false" id="956e-905b-9dda-7175" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -4281,42 +4282,48 @@
     </profile>
     <profile name="Da Boyz" hidden="false" id="7a44-b74f-ad39-c2c8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army must include one Black Orc Boss for every Black Orc Mob it include and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army must include one Black Orc Boss for every Black Orc Mob it includes, and vice versa. In other words:
+•	For each Black Orc Mob your army includes, it must also include one Black Orc War Boss or Big Boss.
+•	For each Black Orc War Boss or Big Boss your army includes, it must also include one Black Orc Mob.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fear of Elves" hidden="false" id="6cb0-9d5a-f165-e272" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Elves of any type cause Fear in modles with this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Elves of any type cause Fear in models with this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ignore Goblin Panic" hidden="false" id="78e4-fffe-6662-41fe" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="45" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make Panic test when friendly Goblin unit is destroyed or Breaks and flee from combat while whithin 6&apos; of it. Nor does this unit have to make a Panic test when it is fled through by friendly Goblin unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make a Panic test when a friendly Goblin unit is destroyed or Breaks and flees from combat whilst within 6&quot; of it. Nor does this unit have to make a Panic test when it is fled through by a friendly Goblin unit.
+Note that, for the purposes of this rule, a Goblin unit is considered to be any unit that is made up entirely of Goblins of any kind, mounted or otherwise. This includes any war machine or chariot that is crewed entirely by Goblins. Should a Goblin unit be joined by an Orc character, it is no longer considered to be a Goblin unit.
+On the following pages you will find a full description for each of the army special rules used by models drawn from the Orc &amp; Goblin Tribes army list:</characteristic>
       </characteristics>
     </profile>
     <profile name="Ignore Panic" hidden="false" id="a097-2e5c-8366-efc1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make Panic test when friendly  unit that does not also have this special rule is destroyed or Breaks and flee from combat while whithin 6&apos; of it. Nor does this unit have to make a Panic test when it is fled through unit that does not have this special rule</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit does not have to make a Panic test when a friendly unit that does not also have this special rule is destroyed or Breaks and flees from combat whilst within 6&quot; of it. Nor does this unit have to make a Panic test when it is fled through by a friendly unit that does not have this special rule..</characteristic>
       </characteristics>
     </profile>
     <profile name="Quell Impetuosity" hidden="false" id="2fb3-330c-b6cb-fc2d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">While within 6&apos; of a unit with this special rule, friendly units may chose to ignore the Impetuous special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst within 6&quot; of a unit with this special rule, friendly units may choose to ignore the Impetuous special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Tusker Charge" hidden="false" id="c392-507a-daf5-126" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged a War Boar&apos;s Tusk (hand weapon) have a Strength characteristic of +1 and Armour Piercing characteristic of +1</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it charged, a War Boar’s Tusks (hand weapon) have a Strength characteristic of S+1 and an Armour Piercing characteristic of -1.
+Note that this special rule only applies to attacks made by a War Boar, not to their rider, a chariot or its crew.</characteristic>
       </characteristics>
     </profile>
     <profile name="Waaagh!" hidden="false" id="7711-627f-5ae5-cc7c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during the Comand sub-phase of their turn, this character may attempt to invoke the power of the Waaagh! by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase this character, their mount and any Orc unit they have joined mat re-roll ant rolls To Hit of natural 1 and when calculating its combat result, may claim an additional bonus of +1 combat result point.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during the Command sub-phase of their turn, this character may attempt to invoke the power of the Waaagh! by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase this character, their mount and any Orc unit they have joined may re-roll any rolls To Hit of a natural 1 and, when calculating its combat result, may claim an additional bonus of +1 combat result point.
+Note that, for the purposes of this rule, an Orc unit is considered to be any unit that is made up entirely of Orcs or Black Orcs, mounted or otherwise. Should an Orc unit be joined by a Goblin character, it is no longer considered to be an Orc unit. This special rule is not cumulative.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warpaint" hidden="false" id="be75-116d-97e0-fbae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="46" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Warpaint gives its wearer 6+ Ward save against wounds suffered. However a model with this special rule can never war armour of any sort (though they may carry a shield).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Warpaint gives its wearer a 6+ Ward save against any wounds suffered. However, a model with this special rule can never wear armour of any sort (though they may carry a shield).</characteristic>
       </characteristics>
     </profile>
     <profile name="Orc Boy" hidden="false" id="5f5d-e3ae-fd89-7005" typeId="b070-143a-73f-2772" typeName="Model">
@@ -4378,12 +4385,13 @@
     </profile>
     <profile name="Netters" hidden="false" id="fc41-af0f-b14a-8eb3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="25" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit combat is chown. during Step 1.1 Chose &amp; Fight Combat sub-phase, it  may attempt to &apos;entangle&apos; one enemy unit it is engaged with. Roll a D6. On a roll of 1; that unit has entangled itself. On a roll of 2+, the enemy unit is entangled. Until the end of the Combat phase, an entangled unit suffers a -1 modifier to its Strength characteristic (to a minimuf of 1)</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, it may attempt to ‘entangle’ one enemy unit it is engaged with. Roll a D6. On a roll of 1, the unit has entangled itself. On a roll of 2+, the enemy unit is entangled. Until the end of the Combat phase, an entangled unit suffers a -1 modifier to its Strength characteristic (to a minimum of 1).
+Note that this modifier is not cumulative.</characteristic>
       </characteristics>
     </profile>
     <profile name="Skulking Menace" hidden="false" id="8186-4d89-630-5b0a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="24" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Nasty Skulkers are not placed on the battlefield ath the start of the game. Instead, make a note of which Goblin Mobs include Nasty Skulkers, and of how many they include. These units are referred as &apos;concealing&apos; units. At the start if its first round of combat, during Step1.1 of the Choose Combat &amp; Fight sub-phase, a concealing unit must  must reveal its Nasty Skulkers - they cannot be revealed at any other time. Position each revealed Nasty Skulkers as you would a character that has joined the unit. Once placed, Nasty Skulker cannot leave their concealing unit. If a concealing unit is destroyed or flees the battlefield before its Nasty Skulkers are revealed, ther are removed as casualties.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Nasty Skulkers are not placed on the battlefield at the start of the game. Instead, make a note of which Goblin Mobs include Nasty Skulkers, and of how many they include. These units are referred to as ‘concealing’ units. At the start of its first round of combat, during Step 1.1 of the Choose Combat &amp; Fight sub-phase, a concealing unit must reveal its Nasty Skulkers – they cannot be revealed at any other time. Position each revealed Nasty Skulker as you would a character that has joined the unit. Once placed, Nasty Skulkers cannot leave their concealing unit. If a concealing unit is destroyed or flees the battlefield before its Nasty Skulkers are revealed, they are removed as casualties.</characteristic>
       </characteristics>
     </profile>
     <profile name="Troll Vomit" hidden="false" id="cdde-5994-8941-787f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -4408,7 +4416,7 @@
     </profile>
     <profile name="Bully" hidden="false" id="f03b-fc52-c489-f365" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="41" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">An orc Bully is an special type of character that can b taken as an upgrade ...</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">An Orc Bully is a special type of character that can be taken as an upgrade to accompany a war machine. During deployment, position an Orc Bully with its war machine, as you would a character that has joined a unit. Once placed, an Orc Bully cannot leave its war machine. Unless this model is fleeing, friendly war machines that are within its Command range can use this model’s Leadership instead of their own.</characteristic>
       </characteristics>
     </profile>
     <profile name="Nasty Skulker" hidden="false" id="3fa1-5e21-bfe-d5a7" typeId="b070-143a-73f-2772" typeName="Model">
@@ -4764,7 +4772,8 @@
     </profile>
     <profile name="Mob Rule" hidden="false" id="dbf3-b0e3-2fa7-b173" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="14" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character has joined a unit of Orcs with Unit Strength of 10 or more, they may apply a +1 modifier to any Casting roll they make. Should they leave the unit for any reason or should the Unit Strength fall below 10, this modifier is lost.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this character has joined a unit of Orcs with a Unit Strength of 10 or more, they may apply a +1 modifier to any Casting roll they make. Should they leave the unit for any reason, or should the unit’s Unit Strength fall below 10, this modifier is lost.
+Note that, for the purposes of this rule, a unit of Orcs is considered to be any unit that is made up entirely of Orcs or Black Orcs, mounted or otherwise.</characteristic>
       </characteristics>
     </profile>
     <profile name="Night Goblin Oddnob" hidden="false" id="d5a8-cb9c-815e-eb95" typeId="b070-143a-73f-2772" typeName="Model">
@@ -5007,9 +5016,15 @@
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [Multiple Wounds (D6)], [Poisoned Attacks], [Strike First]. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Release the Fanatics!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="70d3-ea31-eb40-a58c">
+    <profile name="Release the Fanatics!" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="70d3-ea31-eb40-a58c" page="26" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Fanatics are not placed on the battlefield at the start of the game. Instead, make a note of which Night Goblin units include Fanatics, and of how many they include. These units are referred to as ‘concealing’ units. A concealing unit may release one or more of its Fanatics during any Start of Turn sub-phase.
+When a Fanatic is released, it travels through the air to land spinning several feet away from its concealing unit, before embarking upon its erratic journey across the battlefield. To represent this, place the model so that its base is within 3&quot; of its concealing unit and not touching the bases of any other models.
+Fanatic Movement: During the Compulsory Moves sub-phase of the turn in which it was released, a Fanatic moves 2D6&quot; in a direction chosen by its controlling player. During each and every other Compulsory Moves sub-phase, a Fanatic Moves 2D6&quot; in a random direction. If a Fanatic’s movement brings it into contact with a unit (friend or foe), it moves through that unit. Continue to move it in the same direction until it can be placed on the battlefield with its base not touching the bases of any other models.
+Note that, unlike other models, Fanatics ignore the 1&quot; rule.
+Moving Through a Fanatic: Although dangerous, any unit may move through a Fanatic. Should a unit ever end its move ‘on top’ of a Fanatic, move the Fanatic by the shortest route possible until it can be placed on the battlefield with its base not touching the bases of any models.
+Fanatic Ball &amp; Chain: Any unit (friend or foe) that is moved through by a moving Fanatic, or that moves through a Fanatic, suffers D6 Strength 5 hits, each with an AP of -3.
+Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in any way. However, the life of a Fanatic is no less dangerous for this. Should a Fanatic find itself lying fully or partially underneath a template (one placed over a nearby unit, for example, or that has scattered), it risks being hit as normal. Additionally, if any natural double is rolled for its movement, or if a Fanatic moves into any difficult, dangerous or impassable terrain, or any type of linear obstacle, it comes to a sudden and terminal stop, and is immediately removed from play as a casualty. Finally, if a concealing unit is destroyed or flees the battlefield before its Fanatics have been released, they are removed as casualties.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fanatic" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="5af3-a46d-e0a0-649d">
@@ -5056,9 +5071,9 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">6</characteristic>
       </characteristics>
     </profile>
-    <profile name="Squigs Go Wild" hidden="false" id="3335-f4ef-a032-9cb8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Squigs Go Wild" hidden="false" id="3335-f4ef-a032-9cb8" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="27" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Squig Herd ever Break and flee form a combat, the cave Squigs will go wild. If the Squig Herd contains five or more Cave Squigs, ever unit (friend of foe) within 2D6&quot; of it suffers D3 Strength 5 hits, each with and AP of -1. For very additional five Cave Squigs the Squig Herd contains, apply a +1 Modidier to the D3. Once these hits have been resolved, treat the unit as having been completely destroyed in combat and remove it from play.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Squig Herd ever Break and flee from combat, the Cave Squigs will go wild. If the Squig Herd contains five or more Cave Squigs, every unit (friend or foe) within 2D6&quot; of it suffers D3 Strength 5 hits, each with an AP of -1. For every additional five Cave Squigs the Squig Herd contains, apply a +1 modifier to the D3. Once these hits have been resolved, treat the unit as having been completely destroyed in combat and remove it from play.</characteristic>
       </characteristics>
     </profile>
     <profile name="Huge Gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -5089,9 +5104,9 @@
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Ap-2 [Killing Blow]</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spiked Ball &amp; Chains" hidden="false" id="8188-5c79-c398-cc4b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Spiked Ball &amp; Chains" hidden="false" id="8188-5c79-c398-cc4b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="37" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">[Impact Hits] caused by this model have an Armour Piercing characteristic of -3.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by this model have an Armour Piercing characteristic of -3.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7b8f-602e-29cd-5786" name="The Empire of Man" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="12" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
-    <profile name="Prayers of Ulric" hidden="false" id="d1f4-5e82-b7ed-3ad0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Prayers of Ulric" hidden="false" id="d1f4-5e82-b7ed-3ad0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="53" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to invoke Ulric&apos;s blessings by chanting a single Prayer from the list below and making a Leadership test (using their own Leadership). If this test is passed, the Prayer takes immediate effect.
-
-
-- Battle Howl: Until your next Start of Turn sub-phase, when this model and a single friendly unit that is within its Command range when this Prayer is chanted makes a Charge roll, you may apply a +D3 modifier to the result. This Prayer may only affect models whose troop type is &apos;infantry&apos; or &apos;cavalry&apos;
-- Winter&apos;s Chill: Until your next Start of Turn sub-phase, any enemy model that directs its attacks against this model, its mount or any unit it has joined during the Combat phase must re-roll any roll To Hit of natural 6.
-- Wrath of Winter: Until your next Start of Turn sub-phase, this model, its mount and any unit it has joined gains the Multiple Wounds (2) special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to invoke Ulric’s blessings by chanting a single Prayer from the list below and making a Leadership test (using their own Leadership). If this test is passed, the Prayer takes immediate effect:
+•	Battle Howl: Until your next Start of Turn sub-phase, when this model and a single friendly unit that is within its Command range when this Prayer is chanted* makes a Charge roll, you may apply a +D3 modifier to the result. This Prayer may only affect models whose troop type is ‘infantry’ or ‘cavalry’.
+•	Winter’s Chill: Until your next Start of Turn sub-phase, any enemy model that directs its attacks against this model, its mount or any unit it has joined during the Combat phase must re-roll any rolls To Hit of a natural 6.
+•	Wrath Of Winter: Until your next Start of Turn sub-phase, this model, its mount and any unit it has joined gains the Multiple Wounds (2) special rule.
+*Note that, if more than one friendly unit is within this model’s Command range when this Prayer is chanted, you must tell your opponent which unit is affected.
+Note also that the effects of these Prayers on friendly units are not cumulative. In other words, a friendly unit cannot be affected by the same Prayer more than once during the same turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Symbol of Might" hidden="false" id="5b74-eb4c-8bb7-3e7d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
@@ -17,9 +17,9 @@
 Note that, if this model is your General, it has a Command range of 18&quot; as normal.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Master of Ballistics" hidden="false" id="6fe8-b5a4-2a44-af31" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Master of Ballistics" hidden="false" id="6fe8-b5a4-2a44-af31" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="54" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this model is fleeing or engaged in combat, once per turn a friendly Empire war machine that is within its Command range can either use this model&apos;s Ballistic Skill characteristic, or re-roll a single Artillery dice.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this model is fleeing or engaged in combat, once per turn a friendly Empire war machine that is within its Command range can either use this model’s Ballistic Skill characteristic, or re-roll a single Artillery dice.</characteristic>
       </characteristics>
     </profile>
     <profile name="Suffer Not..." hidden="false" id="d93f-cac1-d68f-5119" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -31,17 +31,17 @@ Note that, if this model is your General, it has a Command range of 18&quot; as 
 - The Daemon: The Witch Hunter and any unit they have joined gains the Hatred (Daemonic models) and Magical Attacks special rules.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Prayers of Sigmar" hidden="false" id="6f59-f4af-ca65-cab9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Prayers of Sigmar" hidden="false" id="6f59-f4af-ca65-cab9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="52" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to invoke Sigmar&apos;s blessings by chanting a single Prayer from the list below and making a Leadership test (using their own Leadership). If this test is passed, the Prayer takes immediate effect.
-
-
-- Hammer of Sigmar: Until your next Start of Turn sub-phase, this model, its mount and a single friendly friendly unit that is within its Command range when tis Prayer is chanted may re-roll any rolls To Hit or To Wound of a natural 1 made during the Combat phase.
-- Shield of Faith: Until your next Start of Turn sub-phase, this model and a single friendly unit that is within its Command range when this Prayer is chanted has a 5+ Ward save against any wounds suffered during the Shooting phase.
-- Soulfire: A single enemy unit this model is engaged in combat with immediately suffers D6 Strength 3 hits, each with an AP of -2. These hits have the Flaming Attacks and Magical Attacks special rules.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to invoke Sigmar’s blessings by chanting a single Prayer from the list below and making a Leadership test (using their own Leadership). If this test is passed, the Prayer takes immediate effect:
+•	Hammer Of Sigmar: Until your next Start of Turn sub-phase, this model, its mount and a single friendly unit that is within its Command range when this Prayer is chanted* may re-roll any rolls To Hit or To Wound of a natural 1 made during the Combat phase.
+•	Shield Of Faith: Until your next Start of Turn sub-phase, this model and a single friendly unit that is within its Command range when this Prayer is chanted* has a 5+ Ward save against any wounds suffered during the Shooting phase.
+•	Soulfire: A single enemy unit this model is engaged in combat with immediately suffers D6 Strength 3 hits, each with an AP of -2. These hits have the Flaming Attacks and Magical Attacks special rules.
+*Note that if more than one friendly unit is within this model’s Command range when this Prayer is chanted, you must tell your opponent which unit is affected.
+Note also that the effects of these Prayers on friendly units are not cumulative. In other words, a friendly unit cannot be affected by the same Prayer more than once during the same turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Master of Battle" hidden="false" id="622-d13-42bf-2d30" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Master of Battle" hidden="false" id="622-d13-42bf-2d30" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="50" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If this model joins a unit of Empire Knights, Inner Circle Knights or Demigryph Knights, that unit will gain the Immune to Psychology special rule. Should this model leave a unit it has joined for any reason, that unit loses this special rule.</characteristic>
       </characteristics>
@@ -141,9 +141,13 @@ Note that a unit with the Unbreakable special rule cannot normally be joined by 
 3- Damage: Any model whose base lies underneath a template risks being hit by this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Cannon" hidden="false" id="b3c6-a5b6-2c6d-73a7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Steam cannon" hidden="false" id="b3c6-a5b6-2c6d-73a7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="69" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S8 AP-2 Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">8</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
@@ -604,14 +608,22 @@ After determining the number of shots, roll To hit for each as normal, using the
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Hochland Long Rifle" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="ec0a-ce53-127c-7c0d">
+    <profile name="Hochland long rifle" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="ec0a-ce53-127c-7c0d" page="77" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">36&quot; S4 AP-1 [Armour Bane (1)], [Cumbersome], [Ponderous]</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">36&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Cumbersome, Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Grenade Launching Blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="b8f7-c4e5-2793-bc18">
+    <profile name="Grenade launching blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="b8f7-c4e5-2793-bc18" page="77" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Pigeon Bombs" hidden="false" id="d71-dbcc-b41f-1429" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -128,6 +128,7 @@ Note that a unit with the Unbreakable special rule cannot normally be joined by 
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">This weapon uses the Black Powder Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Helstorm" hidden="false" id="9081-73c6-4bb0-1de4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" publicationId="8b8d-8fc4-559e-87b1" page="73">
@@ -148,6 +149,7 @@ Note that a unit with the Unbreakable special rule cannot normally be joined by 
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">8</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">This weapon shoots like a cannon, using the ‘Cannon Fire’ special rule. If a ‘Misfire’ is rolled on the Artillery dice during step 2, this model loses a single Wound (instead of rolling on a Misfire table).</characteristic>
       </characteristics>
     </profile>
     <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
@@ -216,6 +218,7 @@ After determining the number of shots, roll To hit for each as normal, using the
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Helstorm, Move or Shoot</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">This weapon uses a number of 3&quot; blast templates and the Black Powder Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Mage" hidden="false" id="af89-8fa1-4a0f-407e" typeId="b070-143a-73f-2772" typeName="Model">
@@ -615,6 +618,7 @@ After determining the number of shots, roll To hit for each as normal, using the
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Cumbersome, Ponderous</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A model armed with a Hochland long rifle can target a specific model within its target unit, such as a champion or a character.</characteristic>
       </characteristics>
     </profile>
     <profile name="Grenade launching blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="b8f7-c4e5-2793-bc18" page="77" publicationId="8b8d-8fc4-559e-87b1">
@@ -624,6 +628,7 @@ After determining the number of shots, roll To hit for each as normal, using the
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Ponderous</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">If the roll To Hit is successful, a grenade launching blunderbuss causes D3+1 hits to the target enemy unit, rather than the usual one hit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Pigeon Bombs" hidden="false" id="d71-dbcc-b41f-1429" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -13,10 +13,8 @@
     </profile>
     <profile name="Symbol of Might" hidden="false" id="5b74-eb4c-8bb7-3e7d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Command range of a Lector of Sigmar mounted on the War Altar is increased from 8&quot; to 12&quot;
-
-
-Note that if this model is your General, it has a Command range of 18&quot; instead.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Command range of a Lector of Sigmar mounted on the War Altar is increased from 8&quot; to 12&quot;.
+Note that, if this model is your General, it has a Command range of 18&quot; as normal.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master of Ballistics" hidden="false" id="6fe8-b5a4-2a44-af31" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -112,19 +110,24 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
     </profile>
     <profile name="Fanatical Zeal" hidden="false" id="a6cf-dfbe-4dcb-153a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="61" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be joined by a Lector of Sigmar or Priest of Sigmar. However, these are the only characters that can join the unit. A Lector of Sigmar or Priest of Sigmar that joins a unit of Flagellants is considered to have the Unbreakable special rule for as long as they remain with the unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be joined by a Lector of Sigmar or a Priest of Sigmar. However, these are the only characters that can join this unit. A Lector of Sigmar or Priest of Sigmar that joins a unit of Flagellants is considered to have the Unbreakable special rule for as long as they remain with the unit.
+Note that a unit with the Unbreakable special rule cannot normally be joined by a character without it. This rule provides an exception that represents the fanaticism of Sigmar’s priesthood.</characteristic>
       </characteristics>
     </profile>
     <profile name="Feel No Pain" hidden="false" id="854c-232c-4091-ac1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="61" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has:
-- A 6+ Ward save against any wounds suffered that were caused by a non-magical enemy attack.
-- A 5+ Ward save against any wounds suffered that were caused by a non-magical enemy attack with Strength 5 or higher.</characteristic>
+•	A 6+ Ward save against any wounds suffered that were caused by a non-magical enemy attack.
+•	A 5+ Ward save against any wounds suffered that were caused by a non-magical enemy attack with a Strength 5 or higher.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Helblaster Volley Gun" hidden="false" id="e8cc-62ef-8348-4584" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Helblaster Volley Gun" hidden="false" id="e8cc-62ef-8348-4584" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="72" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-1 Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Helstorm" hidden="false" id="9081-73c6-4bb0-1de4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" publicationId="8b8d-8fc4-559e-87b1" page="73">
@@ -132,7 +135,7 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Helstorm Rocket Battery launches a barrage of rockets high into the sky passing over intervening regiments and even terrain. When shooting with this weapon, work your way through the following steps:
 1 - Choose target: No line of sight is required for this weapon. Instead, choose an enemy unit that is between its minimum and maximum range to be the target and place D3 blast templates so that the central hole of each is over that unit.
 2 - Scatter: Once each template has been placed, it will scatter. Roll and Artillery dice and a Scatter dice for each template in turn.
- - If A &apos;Misfire&quot; is rolled on the Artillery dice, the rocket has failed to launch. Once all shots from this weapon have been resolved toll once on the appropriate Misfire table for each Misfire rolled.
+ - If A &apos;Misfire&quot; is rolled on the Artillery dice, the rocket has failed to launch. Once all shots from this weapon have been resolved toll once on the appropriate Misfire table for each Misfire rolled.
 - If a &apos;Hit!&apos; is rolled on the Scatter dice, use the small arrow above the Hit! symbol to determine the direction of the scatter and move the template a number of inches equal to the roll of the Artillery dice minus the crew&apos;s Ballistic Skill characteristic (to a minimum of zero).
 - If a arrow is rolled on the Scatter dice, move the template a number of inches equal to the roll of the Artillery dice in the direction the arrow points.
 3- Damage: Any model whose base lies underneath a template risks being hit by this weapon.</characteristic>
@@ -145,20 +148,18 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
     </profile>
     <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">All Wizards within this model&apos;s Command range (friend or foe) suffer a -2 modifier to their Casting rolls.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">All Wizards within this model’s Command range (friend or foe) suffer a -2 modifier to their Casting rolls.</characteristic>
       </characteristics>
     </profile>
     <profile name="Grinding Wheels" hidden="false" id="77c2-c713-163c-883b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="68" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Stomp Attacks made by a Steam Tank have an Armour Piercing characteristic o -2. However, this special rule cannot be used against models whose troop type is &apos;behemoth&apos; - they are simply too large to be caught beneath a Steam Tank&apos;s wheels.
-
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Stomp Attacks made by a Steam Tank have an Armour Piercing characteristic of -2. However, this rule cannot be used against models whose troop type is ‘behemoth’ – they are simply too large to be caught beneath a Steam Tank’s wheels.
 In addition, and unlike other chariots, this model treats low linear obstacles as open terrain rather than as impassable terrain.</characteristic>
       </characteristics>
     </profile>
     <profile name="Steam Power" hidden="false" id="1a22-9799-5f09-36ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="68" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Steam Tank cannot march. Instead you may make a &apos;Steam Power&apos; roll and add the result to the model&apos;s Movement characteristic. To make a Steam Power roll, roll two D6 and discard the lowest result. The higher result is the result of the Steam Power roll. If both dice roll the same number, discard either.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Steam Tank cannot march. Instead, you may make a ‘Steam Power’ roll and add the result to the model’s Movement characteristic. To make a Steam Power roll, roll two D6 and discard the lowest result. The highest result is the result of the Steam Power roll. If both dice roll the same result, discard either.</characteristic>
       </characteristics>
     </profile>
     <profile name="Temperamental" hidden="false" id="1cb7-aebd-815f-6439" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -201,12 +202,16 @@ After determining the number of shots, roll To hit for each as normal, using the
     </profile>
     <profile name="Holy Fervour" hidden="false" id="b1af-d24d-3cdc-e7d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6&quot; of it automatically pass any Fear test they are required to make and can re-roll any failed Panic tests.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6&quot; of it automatically pass any Fear tests they are required to make and can re-roll any failed Panic tests.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Helstorm Rocket Battery" hidden="false" id="4f4b-796c-5654-e56d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Helstorm Rocket Battery" hidden="false" id="4f4b-796c-5654-e56d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="73" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S3 AP-1 Cumbersome, Hellstorm, Move or Shoot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12-48&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Helstorm, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Mage" hidden="false" id="af89-8fa1-4a0f-407e" typeId="b070-143a-73f-2772" typeName="Model">

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -124,7 +124,7 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
     </profile>
     <profile name="Helblaster Volley Gun" hidden="false" id="e8cc-62ef-8348-4584" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-1 Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S5 AP-1 Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Helstorm" hidden="false" id="9081-73c6-4bb0-1de4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" publicationId="8b8d-8fc4-559e-87b1" page="73">
@@ -140,7 +140,7 @@ Note that if this model is your General, it has a Command range of 18&quot; inst
     </profile>
     <profile name="Steam Cannon" hidden="false" id="b3c6-a5b6-2c6d-73a7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S8 AP-2 Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S8 AP-2 Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Witch Bane" hidden="false" id="2285-171-265b-d62a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="67" publicationId="8b8d-8fc4-559e-87b1">
@@ -175,7 +175,7 @@ However, if a natural 1 is rolled on both of the dice, the pressure is too great
     </profile>
     <profile name="Steam Gun" hidden="false" id="145e-aad1-ec61-5b6f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon. No armour saves is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon. No armour saves is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal)</characteristic>
       </characteristics>
     </profile>
     <profile name="Inner Circle" hidden="false" id="99b-d788-7989-4048" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="65" publicationId="8b8d-8fc4-559e-87b1">
@@ -206,7 +206,7 @@ After determining the number of shots, roll To hit for each as normal, using the
     </profile>
     <profile name="Helstorm Rocket Battery" hidden="false" id="4f4b-796c-5654-e56d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S3 AP-1 Cumbersome, Hellstorm, Move or Shoot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S3 AP-1 Cumbersome, Hellstorm, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Mage" hidden="false" id="af89-8fa1-4a0f-407e" typeId="b070-143a-73f-2772" typeName="Model">
@@ -601,17 +601,17 @@ After determining the number of shots, roll To hit for each as normal, using the
     </profile>
     <profile name="Hochland Long Rifle" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="ec0a-ce53-127c-7c0d">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">36&quot; S4 AP-1 [Armour Bane (1)], [Cumbersome], [Ponderous]</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">36&quot; S4 AP-1 [Armour Bane (1)], [Cumbersome], [Ponderous]</characteristic>
       </characteristics>
     </profile>
     <profile name="Grenade Launching Blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="b8f7-c4e5-2793-bc18">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
     <profile name="Pigeon Bombs" hidden="false" id="d71-dbcc-b41f-1429" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Instead of shooting normally during the Shooting phase, a model equipped with pigeon bombs may release one. Choose an enemy unit that is within 24&quot; of the model and roll a D6 on the Pigeon Bomb table below:
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Instead of shooting normally during the Shooting phase, a model equipped with pigeon bombs may release one. Choose an enemy unit that is within 24&quot; of the model and roll a D6 on the Pigeon Bomb table below:
 
 
 1: Bird Brain: Center a small (3&quot;) blast template over the model that released the pigeon bomb. Any model whose base lies underneath the template risks being hit and suffering a Strength 4 hit with an AP of -1.

--- a/The Lores of Magic.cat
+++ b/The Lores of Magic.cat
@@ -887,7 +887,7 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
             <characteristic name="Type" typeId="c2ca-5fd1-5e9d-bc90">Enchantment</characteristic>
             <characteristic name="Casting Value" typeId="d84d-3b8b-654a-9e1a">7+/11+</characteristic>
             <characteristic name="Range" typeId="1043-a0ad-2909-dd28">24’’</characteristic>
-            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If the Bound spell is cast with a casting result of 7 or more, the target friendly unit may re-roll any failed Armour Save rolls. If this Bound spell is cast with a casting value of 11 or more, the target friendly unit may re-roll any failed Armour Save rolls and improves its armour value by 1 (to a maximum of 2+). This spell lasts until your next Start of Turn sub phase.</characteristic>
+            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If the Bound spell is cast with a casting result of 7 or more, the target friendly unit may re-roll any failed Armour Save rolls. If this Bound spell is cast with a casting value of 11 or more, the target friendly unit may re-roll any failed Armour Save rolls and improves its armour value by 1 (to a maximum of 2+). This spell lasts until your next Start of Turn sub phase.</characteristic>
           </characteristics>
         </profile>
         <profile name="Rune of Wrath &amp; Ruin" hidden="false" id="e852-e12c-589a-2b63" typeId="8232-ae14-b1f6-b4df" typeName="Spell">
@@ -905,7 +905,7 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
             <characteristic name="Type" typeId="c2ca-5fd1-5e9d-bc90">Conveyance</characteristic>
             <characteristic name="Casting Value" typeId="d84d-3b8b-654a-9e1a">10+</characteristic>
             <characteristic name="Range" typeId="1043-a0ad-2909-dd28">24&quot;</characteristic>
-            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If the target friendly unit is not fleeing and has already moved during the Movement phase, it may immediately move again.</characteristic>
+            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If the target friendly unit is not fleeing and has already moved during the Movement phase, it may immediately move again.</characteristic>
           </characteristics>
         </profile>
         <profile name="Rune of Hearth &amp; Home" hidden="false" id="5493-33e4-8848-449f" typeId="8232-ae14-b1f6-b4df" typeName="Spell">
@@ -914,7 +914,7 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
             <characteristic name="Type" typeId="c2ca-5fd1-5e9d-bc90">Enchantment</characteristic>
             <characteristic name="Casting Value" typeId="d84d-3b8b-654a-9e1a">7+</characteristic>
             <characteristic name="Range" typeId="1043-a0ad-2909-dd28">Self</characteristic>
-            <characteristic name="Effect" typeId="64ba-31-acf0-5a">Until your next Start of Turn sub-phase, all friendly Dwarf units within 21’’ of the Anvil of Doom gain the [Immune to Psychology] special rule.</characteristic>
+            <characteristic name="Effect" typeId="64ba-31-acf0-5a">Until your next Start of Turn sub-phase, all friendly Dwarf units within 21’’ of the Anvil of Doom gain the [Immune to Psychology] special rule.</characteristic>
           </characteristics>
         </profile>
         <profile name="Master Rune of Calm" typeId="8232-ae14-b1f6-b4df" typeName="Spell" hidden="false" id="a965-eedc-8d1b-96fe">

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -124,6 +124,7 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Extra Attacks (D3)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">In combat, a Sepulchral Stalker may make an additional D3 attacks each turn, each of which must be made with this weapon (roll separately for each model in the unit).</characteristic>
       </characteristics>
     </profile>
     <profile name="Ritual blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="60042717016" publicationId="afac-86a8-e0f-2eef">
@@ -152,6 +153,7 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Poisoned Attacks, Strike First</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fiery roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="143" publicationId="7c89-736c-3139-24a0">

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -108,57 +108,57 @@ A character with this special rule cannot join a unit without this special rule
     </profile>
     <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S6 AP-1 Armour Bane (1), Multiple Wounds (2), Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S6 AP-1 Armour Bane (1), Multiple Wounds (2), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Writhing Tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP1 Extra Attacks(D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1 Extra Attacks(D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Ritual Blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Petryfing Gaze" hidden="false" id="d8-cf66-7b84-5ede" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S2 Magical Attacks, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S2 Magical Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Breath of Dessication" hidden="false" id="8a97-d97-f22f-163b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 Breath Weapon, Magical Attacks, Multiple Wounds (2)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 Breath Weapon, Magical Attacks, Multiple Wounds (2)</characteristic>
       </characteristics>
     </profile>
     <profile name="Envenomed sting" hidden="false" id="fc42-a5d4-da36-c3ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Poisoned Attacks, Strike First. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Poisoned Attacks, Strike First. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fiery Roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Decapitating Claws" hidden="false" id="323c-206b-c9fd-7c8d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP2 Killing Blow, Monster Slayer</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP2 Killing Blow, Monster Slayer</characteristic>
       </characteristics>
     </profile>
     <profile name="Paired Great Khopeshes" hidden="false" id="7b2c-46ee-f170-7afe" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2 Killing Blow, Requires Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 Killing Blow, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Cleaving Blades" hidden="false" id="96c2-db5e-991a-9ba0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP1 Killing Blow</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1 Killing Blow</characteristic>
       </characteristics>
     </profile>
     <profile name="Decapitating Strike" hidden="false" id="8232-8b83-ab9f-3849" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+5 AP-4 Killing Blow, Monster Slayer, Strike Last</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+5 AP-4 Killing Blow, Monster Slayer, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Skulls of Fire" hidden="false" id="e737-8a01-c57c-7917" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -1,73 +1,81 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="11" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="11" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Each time this model suffers an unsaved wound from a [Flaming Attack], your opponent may roll a D6. On a roll of 1-3, the flames quickly die down, and the model escapes further harm. On a roll of 4+, the flames take hold and this model loses one additional Wound. Note that excess wounds caused to a model will have no additional effect except in the case of a character that is part of a challenge, in which case this special rule counts for Overkill. Excess wounds do not ‘spill over’ onto other models in the unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Each time this model suffers an unsaved wound from a Flaming Attack, your opponent may roll a D6. On a roll of 1-3, the flames quickly die down and this model escapes further harm. On a roll of 4+, the flames take hold and this model loses one additional Wound.
+Note that excess wounds caused to a model will have no additional effect except in the case of a character that is part of a challenge, in which case this special rule counts for Overkill. Excess wounds do not ‘spill over’ onto other models in the unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Eternal Taskmaster" hidden="false" id="2cb-b6cc-72e8-ee9e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="130" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to buff a unit they have joined to greater efforts by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase the character and any unit they have joined gains the Extra Attacks (+1) and Hatred (all enemies) special rules.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to drive a unit they have joined to greater efforts by making a Leadership test (using their own Leadership). If this test is passed, until your next Start of Turn sub-phase this character and any unit they have joined gains the Extra Attacks (+1) and Hatred (all enemies) special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Indomitable (X)" hidden="false" id="9e4d-c79a-658d-6900" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule reduces the number of wounds suffered due to the Unstable special rule by the number shown in brackets (shown here as ‘X’). Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest value for the entire unit. For example, if a character with Indomitable (2) joins a unit with Indomitable (1), the whole unit uses the character’s Indomitable (2) special rule</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule reduces the number of wounds suffered due to the Unstable special rule by the number shown in brackets (shown here as ‘X’).
+Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest value for the entire unit. For example, if a character with Indomitable (2) joins a unit with Indomitable (1), the whole unit uses the character’s Indomitable (2) special rule.
+On the following pages you will find a full description for each of the army special rules used by models drawn from the Tomb Kings of Khemri army list:</characteristic>
       </characteristics>
     </profile>
     <profile name="Curse of the Necropolis" hidden="false" id="ccfe-3943-82d5-2a58" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule loses its last Wounds to an enemy attack, the unit that made the attack must immediately make a Leadership test. If this test is failed, the enemy unit suffers D3 Strength 2 hit, each with an AP of -.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule loses its last Wound to an enemy attack, the unit that made the attack must immediately make a Leadership test. If this test is failed, the enemy unit suffers D3 Strength 2 hits, each with an AP of -.</characteristic>
       </characteristics>
     </profile>
     <profile name="Cleaving Blow" hidden="false" id="e8fa-c1b8-3da7-f23d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ’Cleaving Blow’. Enemy models whose troops type is ’regular infantry’, ‘heavy infantry’, ‘light cavalry’ or ’heavy cavalry’ are not permitted an armour or [Regeneration] save against a Cleaving Blow (Ward saves can be attempted as normal). Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ’Cleaving Blow’. Enemy models whose troops type is ’regular infantry’, ‘heavy infantry’, ‘light cavalry’ or ’heavy cavalry’ are not permitted an armour or [Regeneration] save against a Cleaving Blow (Ward saves can be attempted as normal). Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="My Will Be Done" hidden="false" id="abde-68e9-9d0e-a46" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="126" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to exert their will upon those around them by making a Leadership test (using their own Leadership). If the test is passed, choose one of the following modifiers. Until your next Start of Turn sub-phase this character, their mount and any unit they have joined gain that modifier (to a maximum of 10).
-- &quot;Forward to Glory!&quot;: +D3 Movement.
-- &apos;My Worthy Champions!&quot;: +1 Weapon Skill.
-- &quot;Trike like the Cobra!&quot;: +D3 Initiative.
-
-
-Note that this special rule is not cumulative.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this character may attempt to exert their will upon those around them by making a Leadership test (using their own Leadership). If this test is passed, choose one of the following modifiers. Until your next Start of Turn sub-phase this character, their mount and any unit they have joined gain that modifier (to a maximum of 10):
+•	“Forward to Glory!”: +D3 Movement.
+•	“My Worthy Champions!”: +1 Weapon Skill.
+•	“Strike like the Cobra!”: +D3 Initiative.
+Note that this special rule is not cumulative. In other words, using it more than once on the same unit during the same turn has no further effect.</characteristic>
       </characteristics>
     </profile>
     <profile name="Arrows of Asaph" hidden="false" id="d57a-d79-ea09-8dbd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule never apply any modifiers to their rolls To Hit when shooting, regardless of the source of the modifiers.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule never apply any modifiers to their rolls To Hit when shooting, regardless of the source of the modifier.</characteristic>
       </characteristics>
     </profile>
     <profile name="Covenant of Power" hidden="false" id="e499-a9e5-3160-f62d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="148" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst within 12&quot; of a Casket of Souls, friendly Liche Priests may apply a +1 modifier to any Casting roll they make. Additionally, any model (friendly or foe) that casts a Bound spell, whilst within 12&quot; of a Casket of Souls may apply a +1 modifier to the Casting roll.
-Note however that this bonus does not apply to any Bound Spells cast by the Casket of Souls.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst within 12&quot; of a Casket of Souls, friendly Liche Priests may apply a +1 modifier to any Casting roll they make. Additionally, any model (friend or foe) that casts a Bound spell whilst within 12&quot; of a Casket of Souls may apply a +1 modifier to the Casting roll.
+Note, however, that this bonus does not apply to any Bound spells cast by a Casket of Souls.</characteristic>
       </characteristics>
     </profile>
     <profile name="Banner of the King" hidden="false" id="d88f-102f-fef9-dab2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Royal Herald that has been upgraded to be your Battle Standard Bearer replaces the &quot;Hold your Ground&quot; for:
-Friendly unit within the Battle Standard Bearer&apos;s Command range may re-roll any failed Leadership tests. In addition, friendly units within the Battle Standard Bearer Command range reduce the number of Wounds lost die to the Unstable special rule by D3.
-Note that this is not cumulative with the Indomitable (X) special rule. If a unit is affected by both, use the highest value.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Royal Herald that has been upgraded to be your Battle Standard Bearer replaces the “Hold Your Ground” rule given in the Warhammer: the Old World rulebook with the version given below:
+“Hold Your Ground”: Friendly units within the Battle Standard Bearer’s Command range may re-roll any failed Leadership test. In addition, friendly units within the Battle Standard Bearer’s Command range reduce the number of Wounds lost due to the Unstable special rule by D3.
+Note that this is not cumulative with the Indomitable (X) special rule (see page 153). If a unit is affected by both, use the highest value.</characteristic>
       </characteristics>
     </profile>
     <profile name="Sworn Protector" hidden="false" id="26cd-4c1b-a55b-93a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Monarch of Nehekhara model suffer a hit whilst within 3&quot; of this model, you may choose to transfer that hit and all of its effect onto this model.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Monarch of Nehekhara model suffer a hit whilst within 3&quot; of this model, you may choose to transfer that hit and all of its effects onto this model.</characteristic>
       </characteristics>
     </profile>
     <profile name="Arise!" hidden="false" id="a869-df99-ad99-f255" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="128" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, if they are not engaged in combat, this character may attempt to resurrect the fallen (see page 154) by making a Leadership test (using their own Leadership). If this test is passed, a single friendly unit that has the Nehekharan Undead special rule and is within 12&quot; of this character recovers a number of lost Wounds. However, magically repairing gigantic undead constructs is much harder than raising skeletons from the sand. Therefore, how many Wounds are recovered depends upon the unit’s troop type and this character’s Level of Wizardry:
+•	If the unit’s troop type is ‘regular infantry’, ‘heavy infantry’ or ‘swarms’, it recovers a number of Wounds equal to this character‘s Level of Wizardry +D3.
+•	If the unit’s troop type is ‘light cavalry’, ‘heavy cavalry’ or ‘war beasts’, it recovers a number of Wounds equal to this character‘s Level of Wizardry +1.
+•	If the unit’s troop type is ‘monstrous infantry’, ‘monstrous cavalry’ or ‘light chariot’, it recovers a number of Wounds equal to this character‘s Level of Wizardry.
+•	If the unit’s troop type is ‘heavy chariot’, ‘monstrous creature’, ‘behemoth’ or ‘war machine’, it recovers a single Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="From Beneath the Sands" hidden="false" id="2363-698-c566-4bfb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="129" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50"/>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, if they are not engaged in combat, this character may choose a single friendly unit that has both the Nehekharan Undead and the Ambushers special rules, and that is currently held in reserve, and attempt to summon it by making a Leadership test (using their own Leadership):
+•	If this test is passed, the chosen unit is successfully summoned and can be placed on the battlefield anywhere completely within 12&quot; of this model, but not within 6&quot; of any enemy models. The unit cannot charge during this turn and counts as having moved for the purposes of shooting, but can otherwise act as normal.
+•	If this test is failed, the Ambushers pay no heed to this model&apos;s summons and are delayed until their controlling player’s next turn at least.
+Note that Ambushers arrive automatically at the start of round five as usual.</characteristic>
       </characteristics>
     </profile>
     <profile name="Skeleton Chariot" hidden="false" id="22be-951e-6b32-6af6" typeId="b070-143a-73f-2772" typeName="Model">
@@ -98,17 +106,16 @@ Note that this is not cumulative with the Indomitable (X) special rule. If a uni
     </profile>
     <profile name="Nehekharan Undead" hidden="false" id="cc25-1643-8beb-8c64" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the [Fly (X)] special rule, and choose to move by flying). In addition, all Undead models have the following universal special rules:
-• [Fear]
-• [Unbreakable]
-• I[mmune to Psychology]
-• [Unstable]
-A character with this special rule cannot join a unit without this special rule and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the Fly (X) special rule and choose to move by flying). In addition, all Undead models have the following universal special rules:</characteristic>
       </characteristics>
     </profile>
-    <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="135" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S6 AP-1 Armour Bane (1), Multiple Wounds (2), Volley Fire</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">30&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">6</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Multiple Wounds (2), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Writhing Tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -131,9 +138,13 @@ A character with this special rule cannot join a unit without this special rule
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 Breath Weapon, Magical Attacks, Multiple Wounds (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Envenomed sting" hidden="false" id="fc42-a5d4-da36-c3ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Envenomed sting" hidden="false" id="fc42-a5d4-da36-c3ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Poisoned Attacks, Strike First. In combat, this model may choose to make one of its attacks each turn with this weapon.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Poisoned Attacks, Strike First</characteristic>
       </characteristics>
     </profile>
     <profile name="Fiery Roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -173,7 +184,10 @@ A character with this special rule cannot join a unit without this special rule
     </profile>
     <profile name="The Hierophant" hidden="false" id="c9c5-7aab-8e2e-2646" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="129" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Should this character be slain, the magical animus of the army starts to dissipate. As soon as this character is removed from play as a casualty, all friendly units with the Nehekharan Undead special Rule lose the Regeneration (X) special rule. In addition, at the end of the phase in which this model was removed from play as a casualty, and during each of your Start of Turn sub-phases for the remainder of the game, all friendly units with with the Nehekharan Undead special rule that are currently on the battlefield must make a Leadership test. If this test is failed, the unit loses a number of Wounds equal to the amount, by which it failed the test.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army must include at least one Liche Priest to be its Hierophant. If your army includes several Liche Priests, the Hierophant will be the one with the highest Level of Wizardry. If two or more models have the highest Wizard Level, you may choose which one is the Hierophant when writing your muster list. You must tell your opponent which model is your Hierophant before deploying your army.
+Should the Hierophant be slain, the magical animus of the army starts to dissipate. As soon as the Hierophant is removed from play as a casualty, all friendly units with the Nehekharan Undead special rule lose the Regeneration (X) special rule.
+In addition, at the end of the phase in which your Hierophant was removed from play as a casualty, and during each of your Start of Turn sub-phases for the remainder of the game, all friendly units with the Nehekharan Undead special rule that are currently on the battlefield must make a Leadership test. If this test is failed, the unit loses a number of Wounds equal to the amount by which it failed the test.
+For example: Your army’s Hierophant is destroyed during your opponent’s Shooting phase. At the end of that phase a unit of Skeleton Warriors (Ld 5) makes a Leadership test and rolls a 7 (failing the test by 2). That unit immediately loses two Wounds. During your next Start of Turn sub-phase, the same unit makes another Leadership test, this time rolling a 6, resulting in the loss of one Wound.</characteristic>
       </characteristics>
     </profile>
     <profile name="Immovable Object" hidden="false" id="8ff4-5dcd-f462-1acd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -184,7 +198,7 @@ Note that a Casket of Souls can still pivot freely at any time during its turn a
     </profile>
     <profile name="Cloud of Dust" hidden="false" id="9ada-55bb-3fc4-e52b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="142" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy model that targets the model during the Shooting phase suffers an additional -1 To Hit modifier.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy model that targets this model during the Shooting phase suffers an additional -1 To Hit modifier.</characteristic>
       </characteristics>
     </profile>
     <profile name="Unbound Spirits" hidden="false" id="54de-15ad-9dc8-e4be" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="149" publicationId="7c89-736c-3139-24a0">
@@ -194,12 +208,13 @@ Note that a Casket of Souls can still pivot freely at any time during its turn a
     </profile>
     <profile name="Khopesh" hidden="false" id="b049-caf4-f185-d3d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by a model with this special rule as an Armour Piercing characteristic of -1. Note that this special rule only applies to a single, ordinary hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapon or any other sort of weapon, this special rule ceases to apply.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A hand weapon carried by a model with this special rule has an Armour Piercing characteristic of -1.
+Note that this special rule only applies to a single, ordinary hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
     <profile name="Nehekharan Phalanx" hidden="false" id="da25-5643-68aa-bcc1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may choose not to Give Ground Should it lose a round in combat. However, if the winning side significantly outnumbers the losing side, it will overwhelm the loser. If the Unit Strength of the winning side is more than twice that of the losing side, the unit cannot use this special rule and must Give Ground as normal.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may choose not to Give Ground Should it lose a round in combat. However, if the winning side significantly outnumbers the losing side, it will overwhelm the loser. If the Unit Strength of the winning side is more than twice that of the losing side, the unit cannot use this special rule and must Give Ground as normal.</characteristic>
       </characteristics>
     </profile>
     <profile name="Tomb Guard" hidden="false" id="c30-1885-910e-7397" typeId="b070-143a-73f-2772" typeName="Model">
@@ -599,23 +614,23 @@ Note that a Casket of Souls can still pivot freely at any time during its turn a
     </profile>
     <profile name="Vortex of Souls" hidden="false" id="a10c-954f-cdd4-5116" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="149" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Casket of Souls can cast the following Bound spells, with a Power level of 3.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Casket of Souls can cast the following Bound spells, with a Power Level of 3:</characteristic>
       </characteristics>
     </profile>
     <profile name="Unstoppable Assault" hidden="false" id="fbbb-aba9-7f94-97db" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase of any turn in which this model charged, every attack it makes that causes an unsaved wound allows it to immediately make one additional attack. These additional attacks also benefit from this special rule.
-Note that any unsaved wound caused by the Stomp Attacks (D3) special rule do not benefit from this special rule.</characteristic>
+Note that any unsaved wounds caused by the Stomp Attacks (D3) special rule do not benefit from this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Soul Reaper" hidden="false" id="31d6-475d-5db3-94b6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment but before the first turn begins, nominate a single enemy character. This is the soul marked by the Necrosphinx to journey into the underworld by the battle&apos;s end. This model may re-roll any rolls To Hit of a natural 1 made against the nominated character.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment but before the first turn begins, nominate a single enemy character. This is the soul marked by the Necrosphinx to journey into the underworld by the battle’s end. This model may re-roll any rolls To Hit of a natural 1 made against the nominated character.</characteristic>
       </characteristics>
     </profile>
     <profile name="Skulls of the Foe" hidden="false" id="d9e3-ed61-8048-842" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Until your next Start of Turn sub-phase, any enemy unit that was within 2D6’’ of the central hole of the blast template after scattering suffers a -1 modifier to its Leadership characteristic (to a minimum of 2).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Until your next Start of Turn sub-phase, any enemy unit that was within 2D6’’ of the central hole of the blast template after scattering suffers a -1 modifier to its Leadership characteristic (to a minimum of 2).</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -15,8 +15,7 @@ Note that excess wounds caused to a model will have no additional effect except 
     <profile name="Indomitable (X)" hidden="false" id="9e4d-c79a-658d-6900" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule reduces the number of wounds suffered due to the Unstable special rule by the number shown in brackets (shown here as ‘X’).
-Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest value for the entire unit. For example, if a character with Indomitable (2) joins a unit with Indomitable (1), the whole unit uses the character’s Indomitable (2) special rule.
-On the following pages you will find a full description for each of the army special rules used by models drawn from the Tomb Kings of Khemri army list:</characteristic>
+Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest value for the entire unit. For example, if a character with Indomitable (2) joins a unit with Indomitable (1), the whole unit uses the character’s Indomitable (2) special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Curse of the Necropolis" hidden="false" id="ccfe-3943-82d5-2a58" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
@@ -118,14 +117,22 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Multiple Wounds (2), Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Writhing Tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Writhing tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1 Extra Attacks(D3)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Extra Attacks (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ritual Blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Ritual blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="60042717016" publicationId="afac-86a8-e0f-2eef">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-3 Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Petryfing Gaze" hidden="false" id="d8-cf66-7b84-5ede" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -147,14 +154,22 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Poisoned Attacks, Strike First</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fiery Roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Fiery roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="143" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
-    <profile name="Decapitating Claws" hidden="false" id="323c-206b-c9fd-7c8d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Decapitating claws" hidden="false" id="323c-206b-c9fd-7c8d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="144" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP2 Killing Blow, Monster Slayer</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Killing Blow, Monster Slayer</characteristic>
       </characteristics>
     </profile>
     <profile name="Paired Great Khopeshes" hidden="false" id="7b2c-46ee-f170-7afe" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -162,9 +177,13 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2 Killing Blow, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cleaving Blades" hidden="false" id="96c2-db5e-991a-9ba0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Cleaving blades" hidden="false" id="96c2-db5e-991a-9ba0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1 Killing Blow</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Killing Blow</characteristic>
       </characteristics>
     </profile>
     <profile name="Decapitating Strike" hidden="false" id="8232-8b83-ab9f-3849" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -187,9 +187,13 @@
 Note that if a model uses a weapon that has the Requires To Hands special rule in combat, it cannot also use a shield.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Great Weapon" hidden="false" id="88e3-38f0-92d5-b616" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Great weapon" hidden="false" id="88e3-38f0-92d5-b616" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">
@@ -343,14 +347,22 @@ Note that unless a character also has this special rule, their Leadership cannot
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Spear" hidden="false" id="8a6-cc93-b5fd-6636" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Throwing spear" hidden="false" id="8a6-cc93-b5fd-6636" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. A throwing spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
-    <profile name="Thrusting Spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Thrusting spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. Models whose troop type is &apos;infantry&apos; only. A model wielding a thrusting spear cannot m ake a supporting attack during a turn in which it charged. During a turn it was charged in its front arc, a model wielding a thrusting spear gains +1 modifier to its Initiative against the charging unit(s)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
     <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
@@ -495,11 +507,10 @@ Models that can Fly must begin and end all their movement on the ground. A chara
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model making a shooting attack has this special rule, it ignores any To Hit modifiers caused by partial or full cover.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Immune to Psychology" hidden="false" id="93d9-c75b-f655-30ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Immune to Psychology" hidden="false" id="93d9-c75b-f655-30ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the models in a unit are Immune to Psychology, the unit automatically passes any Fear, Panic or Terror tests it is required to make. However, if the majority of the models in a unit have this special rule, the unit cannot choose to Flee as a charge reaction.
-
-Note that this special rule does not make a unit immune to any test make against Leadership not stated here.</characteristic>
+Note that this special rule does not make a unit immune to any test made against Leadership not stated here.</characteristic>
       </characteristics>
     </profile>
     <profile name="Killing Blow" hidden="false" id="860b-e13a-4710-9bf0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
@@ -598,7 +609,7 @@ Casualty Removal: Against enemy shooting, casualty removal should be divided as 
 Note that excess wounds caused to a model will have no additional effect unless that model is a character, in which case this special rule counts for Overkill. Excess wounds do not &apos;spill over&apos; onto other models in the unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Move or Shoot" hidden="false" id="f384-89df-fa9b-1d33" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Move or Shoot" hidden="false" id="f384-89df-fa9b-1d33" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule cannot be used in the Shooting phase if the model equipped with it moved for any reason during this turn (including rallying and reforming).</characteristic>
       </characteristics>
@@ -794,9 +805,13 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Bolt Thrower" hidden="false" id="36e4-28b4-31ff-39dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Bolt thrower" hidden="false" id="36e4-28b4-31ff-39dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="223" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S6 AP-3 Cumbersome, Move or Shoot, Multiple Wounds (2), Through or Through</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">48&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">6</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-3</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Cumbersome, Move or Shoot, Multiple Wounds (2), Through &amp; Through</characteristic>
       </characteristics>
     </profile>
     <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="226" publicationId="768b-3da1-a182-a1d8">
@@ -813,14 +828,22 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; S4(8) AP-1(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Organ Gun" hidden="false" id="5635-efd8-13b6-c841" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Organ gun" hidden="false" id="5635-efd8-13b6-c841" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="228" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 AP-1 Armour Bane(2), Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">30&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fire Thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Fire thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="229" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5 AP-1  Column of Fire, Cumbersome, Flaming Attack, Move or Shoot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Column of Fire, Cumbersome, Flaming Attacks, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
@@ -832,14 +855,22 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cavalry Spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Cavalry spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Fight in Extra Rank. Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A cavalry&apos;s spear Strength and Armor Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
-    <profile name="Morning Star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Morning star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 A morning star&apos;s Strength modifier applies only during the first round of combat.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
       </characteristics>
     </profile>
     <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
@@ -897,9 +928,13 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater Handgun" hidden="false" id="7f58-91d4-ee6c-3cb7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Repeater handgun" hidden="false" id="7f58-91d4-ee6c-3cb7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
@@ -911,14 +946,22 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater Crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Repeater crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S3 Armour Bane (1), Multiple Shots (2)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater Handbow" hidden="false" id="f187-983f-99f2-5ecd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Repeater handbow" hidden="false" id="f187-983f-99f2-5ecd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots (2), Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Shots (2), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Two Hand Weapon" hidden="false" id="1f58-a56f-e54c-ddc5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -935,14 +978,22 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Throwing axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S+1 Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">9&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Weapon" hidden="false" id="eee5-db12-1271-f2c5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Throwing weapon" hidden="false" id="eee5-db12-1271-f2c5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S Multiple Shots (2), Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">9&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Shots (2), Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Wicked Claws" hidden="false" id="14c0-c7a7-dd09-ea49" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -177,6 +177,7 @@
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Unless specified otherwise, all models are assumed to be equipped with a hand weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shield" hidden="false" id="8997-c74d-3a8d-ecf9" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -354,6 +355,7 @@ Note that unless a character also has this special rule, their Leadership cannot
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A throwing spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Thrusting spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
@@ -363,6 +365,7 @@ Note that unless a character also has this special rule, their Leadership cannot
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Models whose troop type is ‘infantry’ only. A model wielding a thrusting spear cannot make a supporting attack during a turn in which it charged. During a turn in which it was charged in its front arc, a model wielding a thrusting spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
       </characteristics>
     </profile>
     <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
@@ -821,6 +824,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">8</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cannon Fire, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Cannon (of any type) do not use their crew’s Ballistic Skill. Instead, they shoot using the ‘Cannon Fire’ special rule. This weapon uses the Black Powder Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stone Thrower" hidden="false" id="3142-ada8-328d-1615" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -835,6 +839,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">This weapon uses the Black Powder Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fire thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="229" publicationId="768b-3da1-a182-a1d8">
@@ -844,6 +849,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">5</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Column of Fire, Cumbersome, Flaming Attacks, Move or Shoot</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Fire throwers do not use their crew’s Ballistic Skill. Instead, they shoot using the ‘Column of Fire’ special rule. This weapon uses the Black Powder Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
@@ -862,6 +868,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Models whose troop type is ‘cavalry’, ‘monster’ or ‘chariot’ only. A cavalry spear’s Strength and Armour Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
       </characteristics>
     </profile>
     <profile name="Morning star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
@@ -871,6 +878,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A morning star’s Strength modifier applies only during the first round of combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
@@ -889,6 +897,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Requires Two Hands</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A flail’s Strength modifier applies only during the first round of combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
@@ -907,6 +916,7 @@ If an Unstable unit contains any Unstable characters, allocate wounds to the uni
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">Models whose troop type is ‘cavalry’ or ‘monster’ only. A lance can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -112,7 +112,7 @@
     </profileType>
     <profileType name="Weapon" hidden="false" id="cc88-6a7d-41c9-d63e" sortIndex="2">
       <characteristicTypes>
-        <characteristicType id="47f2-ecee-cae0-9ef9" name="Description"/>
+        <characteristicType id="47f2-ecee-cae0-9ef9" name="Free-Text Description"/>
         <characteristicType id="b3d5-9c7e-fbc8-bd67" name="R"/>
         <characteristicType id="4a75-6e2c-f91d-326c" name="S"/>
         <characteristicType id="dda4-3a19-9dfd-2c67" name="AP"/>

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -113,6 +113,11 @@
     <profileType name="Weapon" hidden="false" id="cc88-6a7d-41c9-d63e" sortIndex="2">
       <characteristicTypes>
         <characteristicType id="47f2-ecee-cae0-9ef9" name="Description"/>
+        <characteristicType id="b3d5-9c7e-fbc8-bd67" name="R"/>
+        <characteristicType id="4a75-6e2c-f91d-326c" name="S"/>
+        <characteristicType id="dda4-3a19-9dfd-2c67" name="AP"/>
+        <characteristicType id="21d6-681a-a3ec-cce4" name="Special Rules"/>
+        <characteristicType id="1f46-f4c3-16e1-c349" name="Notes"/>
       </characteristicTypes>
     </profileType>
     <profileType name="Special Rule" hidden="false" id="c1ac-c1c8-f9d5-9673" sortIndex="4">
@@ -167,7 +172,7 @@
     </profile>
     <profile name="Hand Weapon" hidden="false" id="ef45-edcd-18bf-fe1d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Unless specified otherwise, all models are assumed to be equipped with a hand weapon.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Unless specified otherwise, all models are assumed to be equipped with a hand weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shield" hidden="false" id="8997-c74d-3a8d-ecf9" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -180,12 +185,12 @@ Note that if a model uses a weapon that has the Requires To Hands special rule i
     </profile>
     <profile name="Great Weapon" hidden="false" id="88e3-38f0-92d5-b616" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
     <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S3 Armour Bane (1), Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S3 Armour Bane (1), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Heavy Armour" hidden="false" id="c56e-8d1b-bb4-de99" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -205,7 +210,7 @@ Note that if a model uses a weapon that has the Requires To Hands special rule i
     </profile>
     <profile name="Brace of Repeater Handbows" hidden="false" id="fca0-3c32-72da-53b9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots (4), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots (4), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Hatred" hidden="false" id="f4b3-18af-16bf-78dd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -224,12 +229,12 @@ Note that this special rule is not cumulative. If two or more models in a unit h
     </profile>
     <profile name="Pistol" hidden="false" id="4c62-cdd4-4e0c-4265" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Brace of Pistols" hidden="false" id="cdb0-f5d2-68e0-205f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane(1), Multiple Shots (2), Quick Shot.
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane(1), Multiple Shots (2), Quick Shot.
 In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
       </characteristics>
     </profile>
@@ -250,7 +255,7 @@ In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
     </profile>
     <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane(1), Ponderous</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane(1), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Veteran" hidden="false" id="4022-c403-b083-ba83" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
@@ -316,22 +321,22 @@ If both armies contain Vanguard units a roll off determines who moves first. The
     </profile>
     <profile name="Warbow" hidden="false" id="20c1-9325-e604-a558" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Range 24&quot; S S, Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Range 24&quot; S S, Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Additional Hand Weapon" hidden="false" id="300e-9667-fc8c-c763" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Throwing Spear" hidden="false" id="8a6-cc93-b5fd-6636" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. A throwing spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. A throwing spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Thrusting Spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. Models whose troop type is &apos;infantry&apos; only. A model wielding a thrusting spear cannot m ake a supporting attack during a turn in which it charged. During a turn it was charged in its front arc, a model wielding a thrusting spear gains +1 modifier to its Initiative against the charging unit(s)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank. Models whose troop type is &apos;infantry&apos; only. A model wielding a thrusting spear cannot m ake a supporting attack during a turn in which it charged. During a turn it was charged in its front arc, a model wielding a thrusting spear gains +1 modifier to its Initiative against the charging unit(s)</characteristic>
       </characteristics>
     </profile>
     <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
@@ -801,127 +806,127 @@ Note that models in rear ranks use the line of sight of the model at the front o
     </profile>
     <profile name="Bolt Thrower" hidden="false" id="36e4-28b4-31ff-39dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S6 AP-3 Cumbersome, Move or Shoot, Multiple Wounds (2), Through or Through</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S6 AP-3 Cumbersome, Move or Shoot, Multiple Wounds (2), Through or Through</characteristic>
       </characteristics>
     </profile>
     <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S8 AP-2 Armour Bane(2), Cannon Fire, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S8 AP-2 Armour Bane(2), Cannon Fire, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Stone Thrower" hidden="false" id="3142-ada8-328d-1615" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; S4(8) AP-1(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; S4(8) AP-1(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Organ Gun" hidden="false" id="5635-efd8-13b6-c841" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 AP-1 Armour Bane(2), Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S5 AP-1 Armour Bane(2), Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
       </characteristics>
     </profile>
     <profile name="Fire Thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5 AP-1  Column of Fire, Cumbersome, Flaming Attack, Move or Shoot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5 AP-1  Column of Fire, Cumbersome, Flaming Attack, Move or Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Cavalry Spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Fight in Extra Rank. Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A cavalry&apos;s spear Strength and Armor Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Fight in Extra Rank. Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A cavalry&apos;s spear Strength and Armor Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
       </characteristics>
     </profile>
     <profile name="Morning Star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 A morning star&apos;s Strength modifier applies only during the first round of combat.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 A morning star&apos;s Strength modifier applies only during the first round of combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Requires Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Flail" hidden="false" id="b326-5bf3-9b4e-f8ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Requires Two Hands, A flail&apos;s Strength modifier applies only during the first round of combat.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Requires Two Hands, A flail&apos;s Strength modifier applies only during the first round of combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank, Strike First</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank, Strike First</characteristic>
       </characteristics>
     </profile>
     <profile name="Lance" hidden="false" id="3520-64c9-a855-ce9e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1) Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A lance can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1) Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A lance can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Quick Shot, Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Quick Shot, Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Warbow" hidden="false" id="4ba0-4ae4-3ac2-a173" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S3 Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S3 Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Pistol" hidden="false" id="f675-db0d-397c-d873" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Handgun" hidden="false" id="7f58-91d4-ee6c-3cb7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S4 Armour Bane (2), Ponderous</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S4 Armour Bane (2), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S3 Armour Bane (1), Multiple Shots (2)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S3 Armour Bane (1), Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Handbow" hidden="false" id="f187-983f-99f2-5ecd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots (2), Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots (2), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Two Hand Weapon" hidden="false" id="1f58-a56f-e54c-ddc5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Sling" hidden="false" id="eee6-7b1-58de-6ad2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Multiple Shots (2)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
     <profile name="Throwing Axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S+1 Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S+1 Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Throwing Weapon" hidden="false" id="eee5-db12-1271-f2c5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S Multiple Shots (2), Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">9&quot; S Multiple Shots (2), Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Wicked Claws" hidden="false" id="14c0-c7a7-dd09-ea49" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-2</characteristic>
       </characteristics>
     </profile>
     <profile name="Serrated Maw" hidden="false" id="2dea-8d5a-633c-cd7d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Armour Bane(2), Multiple Wounds(2)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Armour Bane(2), Multiple Wounds(2)</characteristic>
       </characteristics>
     </profile>
     <profile name="Base (round 50)" hidden="false" id="2c87-b5d6-e13b-4082" typeId="1ae4-7f34-4055-fd5f" typeName="Base">
@@ -934,7 +939,7 @@ Note that models in rear ranks use the line of sight of the model at the front o
     </profile>
     <profile name="Mortar" hidden="false" id="11c5-c8bc-6ce3-8932" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S2(6) AP-2(-3) Armour Bane (1), Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S2(6) AP-2(-3) Armour Bane (1), Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Base (75x50)" typeId="1ae4-7f34-4055-fd5f" typeName="Base" hidden="false" id="f4be-ad24-1cc9-a6ac">
@@ -947,7 +952,7 @@ Note that models in rear ranks use the line of sight of the model at the front o
     </profile>
     <profile name="Flame Cannon" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="5207-3185-698f-a161">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">description of flame cannon</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">description of flame cannon</characteristic>
       </characteristics>
     </profile>
     <profile name="General" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="609a-2943-a6e1-e002">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="39" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-31d1-bf57-53ea-ad55" name="Warhammer The Old World" battleScribeVersion="2.03" revision="39" type="gameSystem" library="true" authorName="Flammy" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <categoryEntries>
     <categoryEntry name="Characters" hidden="false" id="a4cc-15c9-cfae-1b3b"/>
     <categoryEntry id="f0e3-2e32-8866-ea32" name="Core"/>
@@ -170,9 +170,13 @@
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Hand Weapon" hidden="false" id="ef45-edcd-18bf-fe1d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Hand Weapon" hidden="false" id="ef45-edcd-18bf-fe1d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="213" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Unless specified otherwise, all models are assumed to be equipped with a hand weapon.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
       </characteristics>
     </profile>
     <profile name="Shield" hidden="false" id="8997-c74d-3a8d-ecf9" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -188,9 +192,13 @@ Note that if a model uses a weapon that has the Requires To Hands special rule i
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
-    <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S3 Armour Bane (1), Volley Fire</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">30&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Heavy Armour" hidden="false" id="c56e-8d1b-bb4-de99" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -205,7 +213,7 @@ Note that if a model uses a weapon that has the Requires To Hands special rule i
     </profile>
     <profile name="Close Order" hidden="false" id="883e-e1b1-4fe9-5912" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Close Order formation.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Close Order formation, as described on page 100.</characteristic>
       </characteristics>
     </profile>
     <profile name="Brace of Repeater Handbows" hidden="false" id="fca0-3c32-72da-53b9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -227,9 +235,13 @@ Which enemies are hated varies from model to model and will be shown in brackets
 Note that this special rule is not cumulative. If two or more models in a unit have this special rule, use the highest modifier.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Pistol" hidden="false" id="4c62-cdd4-4e0c-4265" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Pistol" hidden="false" id="4c62-cdd4-4e0c-4265" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane (1), Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Brace of Pistols" hidden="false" id="cdb0-f5d2-68e0-205f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -240,7 +252,7 @@ In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
     </profile>
     <profile name="Stubborn" hidden="false" id="e351-bbd6-f470-b604" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The first time the unit is required to make a break test it may choose no to and will automatically Fall Back in Good Order instead even if the Unit Strength of the winning side is more than twice that of the losing side. A unit that is not Stubborn does not become Stubborn when joined by a character that is. A Stubborn character cannot use this special rule whilst part of a unit that are not Stubborn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The first time this unit is required to make a Break test it may choose not to and will automatically Fall Back in Good Order instead, even if the Unit Strength of the winning side is more than twice that of the losing side. A unit that is not Stubborn does not become Stubborn when joined by a character that is. A Stubborn character cannot use this special rule whilst part of a unit that is not Stubborn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Full Plate Armour" hidden="false" id="9a1d-38b0-7d7-7552" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -250,68 +262,70 @@ In combat: Extra Attacks (+1), Requires To Hands.</characteristic>
     </profile>
     <profile name="Shieldwall" hidden="false" id="32f7-8e30-3fe8-b11e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during a turn in which it was charged, a unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields,may Give Ground rather than Fall Back in Good Order.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during a turn in which it was charged, a unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may Give Ground rather than Fall Back in Good Order.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane(1), Ponderous</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">24&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Veteran" hidden="false" id="4022-c403-b083-ba83" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the models in a unit have this special rule, the unit may re-roll any failed Leadership test.
-
 Note that a Break test is not a Leadership test.</characteristic>
       </characteristics>
     </profile>
     <profile name="Move Through Cover" hidden="false" id="e83e-f127-1904-3858" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not suffer any modifier to their Movement characteristic for moving through difficult or dangerous terrain. In addition, a model with this special rule may re-roll any rolls of 1 when making Dangerous Terrain tests.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not suffer any modifiers to their Movement characteristic for moving through difficult or dangerous terrain. In addition, a model with this special rule may re-roll any rolls of 1 when making Dangerous Terrain tests.</characteristic>
       </characteristics>
     </profile>
     <profile name="Open Order" hidden="false" id="5b67-8535-146c-7cea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt an Open Order formation.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt an Open Order formation, as described on page 182.</characteristic>
       </characteristics>
     </profile>
     <profile name="Scouts" hidden="false" id="fe5e-8838-7fbd-a7ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may be deployed after all other units from both armies. They can be deployed anywhere on the battlefield that is more than 12&quot; away from an enemy model. If deployed in this way, Scouts cannot declare a charge during their first turn.
-
-If both armies contain Scouts, a roll-off should determine which player deploys Scouts first. The player then alternate deploying their scouting units one at a time, starting with the player who won the roll-off.</characteristic>
+If both armies contain Scouts, a roll-off should determine which player deploys Scouts first. The players then alternate deploying their scouting units one at a time, starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
     <profile name="Skirmishers" hidden="false" id="59a5-7eca-ee35-96ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Skirmish formation.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Skirmish formation, as described on page 184.</characteristic>
       </characteristics>
     </profile>
     <profile name="Detachment" hidden="false" id="559-d4c6-b2e8-500f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be fielded as a detachment.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be fielded as a ‘detachment’ (see page 282).</characteristic>
       </characteristics>
     </profile>
     <profile name="Ambushers" hidden="false" id="8c0b-6fe6-dc06-512" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may be held on reserve rather than be deployed on the start of the game. From the beginning of round two onwards roll a D6 during each of your Start of Turn sub phases for each unit of Ambushers in your army that is held on reserve. On a roll of 1-3 the unit is delayed until your next turn at least. On a roll of 4+, the unit arrives entering the battlefield as reinforcements during the Compulsory Moves sub-phase. The unit may be placed on any edge of the battlefield chosen by its controlling player, but cannot be placed within 8&quot; of an enemy model. If any Ambushers are still held on reserve by the start of round five, they arrive automatically.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may be held in reserve rather than be deployed at the start of the game. From the beginning of round two onwards, roll a D6 during each of your Start of Turn sub-phases for each unit of Ambushers in your army that is held in reserve. On a roll of 1-3, the unit is delayed until your next turn at least. On a roll of 4+, the unit arrives, entering the battle as reinforcements during the Compulsory Moves sub-phase. The unit may be placed on any edge of the battlefield, chosen by its controlling player, but cannot be placed within 8&quot; of an enemy model. If any Ambushers are still held in reserve by the start of round five, they arrive automatically.</characteristic>
       </characteristics>
     </profile>
     <profile name="Vanguard" hidden="false" id="691e-10ec-4f7c-a2c4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment units with this special rule may make a Vanguard move. A unit making a Vanguard move moves as described on the Basic Movement rules. It may manoeuvre normally but cannot march.
-
-If both armies contain Vanguard units a roll off determines who moves first. The players then alternate moving their Vanguard units one at a time starting with the player who won the roll-off.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment, units with this special rule may make a Vanguard move. A unit making a Vanguard move moves as described in the Basic Movement rules. It may manoeuvre normally but cannot march.
+If both armies contain Vanguard units, a roll-off determines who moves first. The players then alternate moving their Vanguard units one at a time, starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warband" hidden="false" id="505f-e12d-2e36-31d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Warband gains .????</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Warband gains a positive (+) modifier to its Leadership characteristic equal to its current Rank Bonus, up to a maximum of Leadership 10. However, a Warband cannot use this modifier to its Leadership should it ever choose to make a Restraint test. In addition, if the majority of the models in a unit have this special rule, it may re-roll its Charge roll.
+Note that unless a character also has this special rule, their Leadership cannot be modified by this special rule. A Warband can use either its own modified Leadership, the modified Leadership of a Warband character, or the unmodified Leadership of a non-Warband character, whichever is the higher.</characteristic>
       </characteristics>
     </profile>
     <profile name="Impetuous" hidden="false" id="b664-8530-a988-7ba9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If during the Declare Charge &amp; Charge Reaction sub-phase of its turn, a unit that includes one or more Impetuous models is able to declare charge, roll a D6. On a roll of 1-3, the unit must declare a charge. On a roll of 4+, the unit may act as normal.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If during the Declare Charges &amp; Charge Reactions sub-phase of its turn, a unit that includes one or more Impetuous models is able to declare a charge, roll a D6. On a roll of 1-3, the unit must declare a charge. On a roll of 4+, the unit may act as normal.</characteristic>
       </characteristics>
     </profile>
     <profile name="Light Armour" hidden="false" id="dbb2-4d85-84c2-528c" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -341,13 +355,12 @@ If both armies contain Vanguard units a roll off determines who moves first. The
     </profile>
     <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Frenzied model has a +1 modifier to its Attacks characteristic. This modifier does not apply to the model&apos;s mount (i.e. the mount of a cavalry model), to the beasts that drag it (in the case of a chariot), or to its rider (in the case of a monster).
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Frenzied model has a +1 modifier to its Attacks characteristic. This modifier does not apply to the model’s mount (in the case of a cavalry model), to the beasts that draw it (in the case of a chariot), or to its rider (in the case of a monster).
 In addition:
-
-- If the majority of the models in a unit are Frenzied, the unit automatically passes any Fear, Panic or Terror tests is required to make.
-- If a unit that includes one or more Frenzied models is able to declare a charge during the Declare Charges &amp; Charge Reactions sub-phase of its turn, it must do so.
-- If the majority of the models in a unit are Frenzied, it cannot choose to Flee to a charge reaction, nor can it ever choose to make a Restrain test.
-Loosing Frenzy: Unlike other special rules Frenzy can be lost during a game. Any model that loses a round of combat will immediately lose this special rule.</characteristic>
+•	If the majority of the models in a unit are Frenzied, the unit automatically passes any Fear, Panic or Terror tests it is required to make.
+•	If a unit that includes one or more Frenzied models is able to declare a charge during the Declare Charges &amp; Charge Reactions sub-phase of its turn, it must do so.
+•	If the majority of the models in a unit are Frenzied, it cannot choose to Flee as a charge reaction, nor can it ever choose to make a Restraint test.
+Losing Frenzy: Unlike other special rules, Frenzy can be lost during a game. Any model that loses a round of combat will immediately lose this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Armour Bane" hidden="false" id="2af0-975f-bb14-8b8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -366,19 +379,16 @@ Note that a model that wears no armour is considerer to have an armour value of 
     </profile>
     <profile name="Breath Weapon" hidden="false" id="e049-8b4d-23e9-7505" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with a Breath Weapon can use it once per round, during the Shooting phase of its turn. Place the flame template, with its broad end over the intended target and its narrow end touching the model&apos;s base edge anywhere along its front arc. The template must lie entirely within the model&apos;s vision arc. Any model whose base lies underneath the template risks being hit. The Strength and any special rules of the breath weapon will be detailed in the creature&apos;s rules.
-
-Breath weapons cannot be used when making a [Stand &amp; Shoot] charge reaction, or when the model is engaged in combat.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with a Breath Weapon can use it once per round, during the Shooting phase of its turn. Place the flame template with its broad end over the intended target and its narrow end touching the model’s base edge anywhere along its front arc. The template must lie entirely within the model’s vision arc. Any model whose base lies underneath the template risks being hit, as described on page 95. The Strength and any special rules of the breath weapon will be detailed in the creature’s rules.
+Breath weapons cannot be used when making a Stand &amp; Shoot charge reaction, or when the model is engaged in combat.
+The flame template is placed with the narrow end touching the model’s base edge, within its forward arc, and the broad end over the target unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Counter Charge" hidden="false" id="5186-798d-69d-6545" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This special rule can only be used by units that consists entirely of models with this special rule. When a unit with this special rule is charged in its front arc by an enemy unit whose troop type is &apos;cavalry&apos;, &apos;chariot&apos; or &apos;monster&apos;, it may declare a &apos;Counter Charge&apos; charge reaction.
-
-Counter charge: The unit surges forward to meet the enemy charge. Measure the distance between the two units. If the distance is less than the Movement characteristic of the charging unit, the charged unit has not enough time to meet the enemy charge and must either Hold of Flee instead.
-
-Otherwise, pivot the unit about its center so that it is facing directly towards the centre of the charging enemy unit. After pivoting, the unit moves D3+1&quot; directly towards the enemy unit. Both units are considered to have charged during this turn.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This special rule can only be used by units that consist entirely of models with this special rule. When a unit with this special rule is charged in its front arc by an enemy unit whose troop type is ‘cavalry,’ ‘chariot’ or ‘monster’, it may declare a ‘Counter Charge’ charge reaction:
+Counter Charge: The unit surges forward to meet the enemy charge. Measure the distance between the two units. If the distance is less than the Movement characteristic of the charging unit, the charged unit has not enough time to meet the enemy charge and must either Hold or Flee instead.
+Otherwise, pivot the unit about its centre so that it is facing directly towards the centre of the charging enemy unit. After pivoting, the unit moves D3+1&quot; directly towards the enemy unit. Both units are considered to have charged during this turn.
 Fleeing units and units already engaged in combat when charged cannot Counter Charge. A unit can only Counter Charge in response to one charge per turn, even if charged by multiple units. Once all charges have been declared, the inactive player can choose which charging unit to Counter Charge. The unit will then Hold against the other charging units.</characteristic>
       </characteristics>
     </profile>
@@ -389,24 +399,23 @@ Fleeing units and units already engaged in combat when charged cannot Counter Ch
     </profile>
     <profile name="Dragged Along" hidden="false" id="a042-c2f5-ebcb-2bab" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule that begins its movement within 1&quot; of a friendly unit whose troop type is &apos;infantry&apos; that is not fleeing and that contains ten or more models may replace its Movement characteristic with that of the unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule that begins its movement within 1&quot; of a friendly unit whose troop type is ‘infantry,’ that is not fleeing and that contains ten or more models, may replace its Movement characteristic with that of the unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Drilled" hidden="false" id="1f64-3ddc-db58-12fb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Drilled unit may perform a free redress the ranks manoeuvre immediately before moving. Once this manoeuvre is complete, the unit moves as normal. In addition a Drilled unit can march whilst within 8&quot; of an enemy unit without first having to make a Leadership test.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Drilled unit may perform a free redress the ranks manoeuvre immediately before moving. Once this manoeuvre is complete, the unit moves as normal. In addition, a Drilled unit can march whilst within 8&quot; of an enemy unit without first having to make a Leadership test.
 Note that any character that joins a Drilled unit is considered to be Drilled as well.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ethereal" hidden="false" id="6561-8029-dac3-162" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Ethereal creatures treat all terrain as open ground for the purpose of movement. They cannot end their movement inside impassible terrain, though they can pass through it. In addition, Ethereal creatures can only be wounded by Magical attacks. Characters that are not Ethereal cannot join units that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Ethereal creatures treat all terrain as open ground for the purposes of movement. They cannot end their movement inside impassable terrain, though they can pass through it. In addition, Ethereal creatures can only be wounded by Magical attacks. Characters that are not Ethereal cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Evasive" hidden="false" id="9fff-999f-6e96-e149" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, when the unit is declared the target during the enemy Shooting phase, it may choose to Fall Back in Good Order and will flee directly away form the enemy unit shooting at it. Once this unit has completed its move, the enemy unit may continue with its shooting as declared.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, when this unit is declared the target during the enemy Shooting phase, it may choose to Fall Back in Good Order and will flee directly away from the enemy unit shooting at it. Once this unit has completed its move, the enemy unit may continue with its shooting as declared.</characteristic>
       </characteristics>
     </profile>
     <profile name="Extra Attacks" hidden="false" id="23c7-1aeb-5f02-c9e1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -416,49 +425,43 @@ Note that any character that joins a Drilled unit is considered to be Drilled as
     </profile>
     <profile name="Fast Cavalry" hidden="false" id="df-a39-e62-1c57" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If all of the models (including Characters) within a unit arrayed in an Open Order formation have this special rule, the unit may perform its Quick Turn even if marched.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If all of the models (including characters) within a unit arrayed in an Open Order formation have this special rule, the unit may perform its Quick Turn (see page 183) even if it marched.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fear" hidden="false" id="5ec9-a98-d8c5-e18b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot flee.
-
-If a unit wishes to declare a charge against an enemy unit that both causes Fear and has a higher Unit Strength, it must first make a Leadership test. If this test is failed, the unit cannot charge. It does not move and is considered to have make a failed charge. If this test is passed, the unit can charge as normal.
-
-If a unit is engaged with an enemy unit that both causes Fear and has a higher Unit Strength when its combat is chosen during any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is failed, any models in the unit that direct their attacks against the Fear-causing enemy suffer a -1 modifier to their rolls To Hit.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Fear:
+•	If a unit wishes to declare a charge against an enemy unit that both causes Fear and has a higher Unit Strength, it must first make a Leadership test. If this test is failed, the unit cannot charge. It does not move and is considered to have made a failed charge. If this test is passed, the unit can charge as normal.
+•	If a unit is engaged with an enemy unit that both causes Fear and has a higher Unit Strength when its combat is chosen during any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is failed, any models in the unit that direct their attacks against the Fear-causing enemy suffer a -1 modifier to their rolls To Hit.
 A unit only needs to make one Fear test per turn. Models that cause Fear are immune to Fear. A unit that does not cause Fear does not become immune to Fear when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
     <profile name="Feigned Flight" hidden="false" id="eea7-89d9-a996-403c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit chooses to Flee (or Fire &amp; Flee) as a charge reaction, it automatically rallies at the end of its move.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit chooses to Flee (or Fire &amp; Flee) as a charge reaction, it automatically rallies at the end of its move, as described on page 117.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fight In Extra Rank" hidden="false" id="b49e-b47f-fb38-596e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may make a supporting attack.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may make a supporting attack, as described on page 145.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fire &amp; Flee" hidden="false" id="1a06-31aa-cbfe-1a5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is also armed with missile weapons may declare that it will &apos;Fire &amp; Flee&apos; as a charge reaction.
-
-Fire and Flee: The unit launches a volley of weapons fire before turning to flee form the enemy. If a unit with this special rule is armed with missile weapons and can draw line of sight to the charging unit, it may declare that it will Fire &amp; Flee. The unit will Stand &amp; Shoot before turning tail and fleeing from the charge. However, due to the time spent shooting at the charging foe, when making its Flee roll the unit rolls two D6 and discards the lowest result. If both dice roll the same result, discard either.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is also armed with missile weapons may declare that it will ‘Fire &amp; Flee’ as a charge reaction:
+Fire &amp; Flee: The unit launches a volley of weapons fire before turning to flee from the enemy. If a unit with this special rule is armed with missile weapons and can draw a line of sight to the charging unit, it may declare that it will Fire &amp; Flee. The unit will Stand &amp; Shoot (as described on page 120) before turning tail and fleeing from the charge. However, due to the time spent shooting at the charging foe, when making its Flee roll the unit rolls two D6 and discards the lowest result. If both dice roll the same result, discard either.
 Note that, if the distance between this unit and the charging unit is less than the Movement characteristic of the charging unit, this unit must either Hold or Flee.</characteristic>
       </characteristics>
     </profile>
     <profile name="First Charge" hidden="false" id="785a-2886-af42-dce9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit&apos;s first charge of the game is successful (i.e. if the unit makes contact with the charge target), the charge target becomes Disrupted unit the end of the Combat phase of that turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit’s first charge of the game is successful (i.e., if the unit makes contact with the charge target), the charge target becomes Disrupted until the end of the Combat phase of that turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Flaming Attacks" hidden="false" id="e45d-952-f679-ae2c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made of hits caused by a model with this special rule or made using a weapon or spell with this special rule, is a &quot;Flaming&quot; attack. In addition, a model with this special rule causes Fear to models which troop type is &apos;war beasts&apos; or &apos;swarms&apos;.
-
-Unless otherwise stated, a model with this special rule makes Flaming attacks both when shooting and in combat (though any spells cast by the model are unaffected, as are any attacks made with magic weapons they might be weilding).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hits caused by a model with this special rule, or made using a weapon or spell with this special rule, is a ‘Flaming’ attack. In addition, a model with this special rule causes Fear (as described on page 168) in models whose troop type is ‘war beasts’ or ‘swarms’.
+Unless otherwise stated, a model with this special rule makes Flaming attacks both when shooting and in combat (though any spells cast by the model are unaffected, as are any attacks made with magic weapons they might be wielding).</characteristic>
       </characteristics>
     </profile>
     <profile name="Flammable" hidden="false" id="8f64-6d4c-466b-1b94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
@@ -501,14 +504,13 @@ Note that this special rule does not make a unit immune to any test make against
     </profile>
     <profile name="Killing Blow" hidden="false" id="860b-e13a-4710-9bf0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it ha struck a &apos;Killing Blow&apos;. Enemy models whose troop type is &apos;infantry&apos; or &apos;cavalry&apos; are not permitted an armour save or Regeneration save against a Killing Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is &apos;infantry&apos; or &apos;cavalry&apos; suffers an unsaved wound from Killing Blow, it looses all of its remaining Wounds.
-
-Note that if an attack wounds automatically this special rule cannot be used/</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ‘Killing Blow’. Enemy models whose troop type is ‘infantry’ or ‘cavalry’ are not permitted an armour or Regeneration save (see page 176) against a Killing Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is ‘infantry’ or ‘cavalry’ suffers an unsaved wound from a Killing Blow, it loses all of its remaining Wounds.
+Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="Levies" hidden="false" id="8cc3-d6f5-da17-6600" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot use Inspiring Presence rule of the army&apos;s general nor the Hold your Ground rule of a Battle Standard. However, little is expected from Levies in battle. Therefore units that do not have this special rule are not required to make a Panic test when a friendly unit of Levies Breaks and flees from combat.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot use the Inspiring Presence rule of the army’s General nor the Hold your Ground rule of a Battle Standard. However, little is expected from Levies in battle. Therefore, units that do not have this special rule are not required to make a Panic test when a friendly unit of Levies Breaks and flees from combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Loner" hidden="false" id="2ecd-c6b3-bd8b-864b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
@@ -518,31 +520,29 @@ Note that if an attack wounds automatically this special rule cannot be used/</c
     </profile>
     <profile name="Magical Attacks" hidden="false" id="2125-6aa2-f782-42bf" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hit caused by a mode with this special rule, or made using a weapon with this special rule, is a &apos;Magical&apos; attack.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hit caused by a model with this special rule, or made using a weapon with this special rule, is a ‘Magical’ attack.
 Note that all spells are considered to have this special rule, as are any hits caused by magic items.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mercenaries" hidden="false" id="4d1b-2617-ebdc-4f4d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Often, an army can include certain units drawn from another army list as mercenaries. Any such units included in your army gain this special rule. Mercenaries cannot use the Inspiring Presence rule of the army&apos;s general nor the Hold the Ground rule of a Battle Standard. Mercenaries cannot be joined by characters drawn form another army list.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Often, an army can include certain units drawn from another army list as mercenaries. Any such units included in your army gain this special rule. Mercenaries cannot use the Inspiring Presence rule of the army’s General (see page 203) nor the Hold your Ground rule of a Battle Standard (see page 203). Mercenaries cannot be joined by characters drawn from another army list.</characteristic>
       </characteristics>
     </profile>
     <profile name="Monster Handlers" hidden="false" id="1084-a4e9-79f-3462" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A monster with this special rule is accompanied by one or more models representing its handlers. During deployment, position these models anywhere that is adjacent to, an in base contact with, the monster. If the handlers are found to be blocking movement or line of sight, simply move them aside.
-
-In combat, each handler adds its attacks to those of the monster. If the monster suffers an unsaved wound, roll a D6. On a roll of 1-4 the monster looses a Wound, but on a roll of 5+ a handler model suffers the wound instead. If the monster is removed from play, so are its handlers.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A monster with this special rule is accompanied by one or more models representing its handlers. During deployment, position these models anywhere that is adjacent to, and in base contact with, the monster. If the handlers are found to be blocking movement or line of sight, simply move them aside.
+In combat, each handler adds its attacks to those of the monster. If the monster suffers an unsaved wound, roll a D6. On a roll of 1-4 the monster loses a Wound, but on a roll of 5+ a handler model suffers the wound instead. If the monster is removed from play, so are its handlers.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chariot Runners" hidden="false" id="afa3-a46a-2608-f62c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Friendly models whose troop type is &apos;chariot&apos; can draw a line of sight over or through models with this special rule and can move through friendly units of Chariot Runners that are in Skirmish formation. If the chariot&apos;s move would result in it ending up &apos;on top&apos; of a Chariot Runner, simple nudge the Chariot Runner aside by the smallest amount possible, to make space for the chariot. Whilst in Skirmish formation units of Chariot Runners can treat friendly chariots that are within 1&quot; of one or more of the unit&apos;s models as part of the unit for the purpose of unit coherency.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Friendly models whose troop type is ‘chariot’ can draw a line of sight over or through models with this special rule and can move through friendly units of Chariot Runners that are in Skirmish formation. If the chariot’s move would result in it ending up ‘on top’ of a Chariot Runner, simply nudge the Chariot Runner aside, by the smallest amount possible, to make space for the chariot. Whilst in Skirmish formation units of Chariot Runners can treat friendly chariots that are within 1&quot; of one or more of the unit’s models as a part of the unit for the purposes of unit coherency.</characteristic>
       </characteristics>
     </profile>
     <profile name="Howdah" hidden="false" id="b8f6-1cbc-b19-c7b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">To represent its howdah and crew, a behemoth with this special rule has a split profile and follows both the &apos;Split Profile (Chariots)&apos; and &apos;Firing Platform&apos; rules. In all other respects, this model is a behemoth.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">To represent its howdah and crew, a behemoth with this special rule has a split profile and follows both the ‘Split Profile (Chariots)’ and ‘Firing Platform’ rules (see page 194). In all other respects, this model is a behemoth.</characteristic>
       </characteristics>
     </profile>
     <profile name="Impact Hits" hidden="false" id="5c2-e9dd-2715-a0c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -554,24 +554,20 @@ Resolving Impact Hits: Impact Hits can only be made by a charging model that mov
     </profile>
     <profile name="Large Target" hidden="false" id="c822-7ad0-f24a-e4af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models never suffer To Hit modifiers for full or partial cover when shooting at models with this special rule. In addition, a model can draw a line of sight to a model with this special rule over or though other models and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models never suffer To Hit modifiers for full or partial cover when shooting at models with this special rule. In addition, a model can draw a line of sight to a model with this special rule over or through other models, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Monster Slayer" hidden="false" id="6b2f-7ce0-3e27-4ded" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a &apos;Monster Slaying Blow&apos;. Enemy models whose troop type is &apos;monster&apos; are not permitted an armour or Regeneration save against a Monster Slaying Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is &apos;monster&apos; suffers an unsaved wound from a Monster Slaying Blow, it loses all of it remaining Wounds.
-
-Note that if an attack wounds automatically this special rule cannot be used.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ‘Monster Slaying Blow’. Enemy models whose troop type is ‘monster’ are not permitted an armour or Regeneration save (see page 176) against a Monster Slaying Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is ‘monster’ suffers an unsaved wound from a Monster Slaying Blow, it loses all of its remaining Wounds.
+Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="Motley Crew" hidden="false" id="6359-4018-5cd4-3720" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may include models of the same type that are equipped differently to one another, and/or models of different types that fight together in a single unit. If necessary, the army list entry for such units will be accompanied by a brief explanation of the unit&apos;s composition.
-
-Different Weapons: The fighting rank of a Motley Crew may contain models what are armed with different weapons. In each case, the controlling player must roll different batches of dice for the different models, making it clear to their opponent which model&apos;s attacks they represent and where they are being directed. These attacks are made in the Initiative order of the individual models, as usual.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may include models of the same type that are equipped differently to one another, and/or models of different types that fight together in a single unit. If necessary, the army list entry for such units will be accompanied by a brief explanation of the unit’s composition.
+Different Weapons: The fighting rank of a Motley Crew may contain models that are armed with different weapons. In such cases, the controlling player must roll different batches of dice for the different models, making it clear to their opponent which model’s attacks they represent and where they are being directed. These attacks are made in the Initiative order of the individual models, as usual.
 Different Armour: Models within a Motley Crew may have different armour values. In combat, use the armour value of the majority of the models in the fighting rank. Against enemy shooting, use the armour value of the majority of the models in the unit.
-
 Casualty Removal: Against enemy shooting, casualty removal should be divided as equally as possible between the different models within the unit. In combat, casualties should be removed from among the majority of the models that make up the fighting rank. In either case, available models are brought forward from rear ranks to fill any gaps, as chosen by the controlling player.</characteristic>
       </characteristics>
     </profile>
@@ -582,7 +578,7 @@ Casualty Removal: Against enemy shooting, casualty removal should be divided as 
     </profile>
     <profile name="Rallying Cry" hidden="false" id="23c4-bd19-2422-ad08" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the command sub-phase of their turn, if they are nor engaged in combat, this character may nominate a single fleeing friendly unit that is within their Command range. The nominated unit immediately makes a Rally test. If the test is failed the unit may attempt to rally again as normal during the Rally sub-phase</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, if they are not engaged in combat, this character may nominate a single fleeing friendly unit that is within their Command range. The nominated unit immediately makes a Rally test. If this test is failed, the unit may attempt to rally again as normal during the Rally sub-phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Quick Shot" hidden="false" id="f733-b74b-6cb1-c69" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
@@ -615,32 +611,31 @@ Note that excess wounds caused to a model will have no additional effect unless 
     <profile name="Poisoned Attacks" hidden="false" id="81f5-4895-4abc-fc39" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with Poisoned Attacks rolls a natural 6 when making a roll To Hit, that hit will wound automatically. Unless otherwise stated, a model with this special rule may use it when making both shooting and combat attacks. Any spells cast by the model are unaffected, as are any attacks made with magic weapons.
-
 Note that if an attack needs a To Hit roll of 7+, or hits automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="Random Attacks" hidden="false" id="1b08-4621-6379-ff1f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Attacks characteristic. Instead, a dice roll is given (D3+1, for example). Each time a model with this special rule attacks in combat, roll a dice to determine the number of attacks it will make, then roll To Hit as normal. If a fighting rank contains mode than one model with this special rule, roll separately for each, unless specified otherwise.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Attacks characteristic. Instead, a dice roll is given (D3+1, for example). Each time a model with this special rule attacks in combat, roll the dice to determine the number of attacks it will make, then roll To Hit as normal. If a fighting rank contains more than one model with this special rule, roll separately for each, unless specified otherwise.</characteristic>
       </characteristics>
     </profile>
     <profile name="Random Movement" hidden="false" id="4924-fc1f-bcd-746a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule move during the Compulsory Moves sub-phase. They cannot march or declare a charge. They can wheel to change direction, but cannot perform any other manoeuvres. If the model is able to make contact with an enemy unit during the Compulsory Moves sub-phase or whilst pursuing, it may do so and counts as having charged. The model aligns against the enemy unit and stops moving. A unit charged in this way must Hold.
-
-If every model in a unit has this special rule, toll once for the entire unit. If two or more models in a unit have different Random Movement characteristics, roll for each and use the lowest result for the entire unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Movement characteristic. Instead, a dice roll is given (2D6, for example). Whenever a model with this special rule moves (for any reason), roll the dice to determine how far it must move.
+Models with this special rule move during the Compulsory Moves sub-phase. They cannot march or declare a charge. They can wheel to change direction, but cannot perform any other manoeuvres. If the model is able to make contact with an enemy unit during the Compulsory Moves sub-phase or whilst pursuing, it may do so and counts as having charged. The model aligns against the enemy unit and stops moving. A unit charged in this way must Hold.
+If every model in a unit has this special rule, roll once for the entire unit. If two or more models in a unit have different Random Movement characteristics, roll for each and use the lowest result for the entire unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Regeneration" hidden="false" id="2eb0-1ec8-8e04-72d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule can make a &apos;Regeneration&apos; save. The armour value of a Regeneration save is shown in brackets after the name of this special rule (X+). A Regeneration save can never be modified by the AP characteristic of a weapon and can be made in addition to an armour save and  Ward save. However, any wounds saved by a Regeneration save are still counted for the purposes of calculating combat result.
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule can make a &apos;Regeneration&apos; save. The armour value of a Regeneration save is shown in brackets after the name of this special rule (X+). A Regeneration save can never be modified by the AP characteristic of a weapon and can be made in addition to an armour save and  Ward save. However, any wounds saved by a Regeneration save are still counted for the purposes of calculating combat result.
 
 Note that models with this special rule are often vulnerable to the Flaming Attacks or Magical Attacks special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Regimental Unit" hidden="false" id="7424-ec43-7581-965a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be accompanied by &apos;detachments&apos;.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be accompanied by ‘detachments’ (see page 282).</characteristic>
       </characteristics>
     </profile>
     <profile name="Requires Two Hands" hidden="false" id="4f8d-35e-6be9-dabb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
@@ -650,7 +645,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
     </profile>
     <profile name="Reserve Move" hidden="false" id="1f10-d7d-be19-7e8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless is charged, marched or fled during the Movement phase of its turn, a unit with this special rule may make a Reserve move at the end of the Shooting phase of its turn, after all shooting has been resolved. A unit making a Reserve move moves as described in the Basic Movement rules. It may manoeuvre but cannot march.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it charged, marched or fled during the Movement phase of its turn, a unit with this special rule may make a Reserve move at the end of the Shooting phase of its turn, after all shooting has been resolved. A unit making a Reserve move moves as described in the Basic Movement rules. It may manoeuvre normally, but cannot march.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stomp Attacks" hidden="false" id="72db-24bb-7493-d753" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -662,67 +657,62 @@ Resolving Stomp Attacks: Stomp Attacks can only be made by a model that is in ba
     </profile>
     <profile name="Strike First" hidden="false" id="48fd-23c1-c0d5-ae1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rile that is engaged in combat improves its Initiative characteristic to 10 (before any other modifiers are applied). If a model has both this rule and Strike Last, the two rules cancel each other out.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rule that is engaged in combat improves its Initiative characteristic to 10 (before any other modifiers are applied). If a model has both this rule and Strike Last, the two rules cancel one another out.</characteristic>
       </characteristics>
     </profile>
     <profile name="Strike Last" hidden="false" id="7c4d-72c1-eeb-ab5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase a model with this special rule that is engaged in combat  reduces its Initiative characteristic to 1 (before any other modifiers are applied). If a model has both this rule and Strike First, the two rules cancel each other out.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rule that is engaged in combat reduces its Initiative characteristic to 1 (before any other modifiers are applied). If a model has both this rule and Strike First, the two rules cancel one another out.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stupidity" hidden="false" id="f7af-e016-1f9c-54c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is engaged in combat, a unit with this special rule must make a &apos;Stupidity&apos; test during the Start of Turn sub-phase of its turn. To make a Stupidity test, test against the unit&apos;s Leadership characteristic. If this test is failed the unit becomes Stupid. A Stupid unit:
-
-- Moves during the Compulsory Moves sub-phase.
-- Must move straight ahead, without performing any manoeuvres.
-- Cannot march or declare a charge.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is engaged in combat, a unit with this special rule must make a ‘Stupidity’ test during the Start of Turn sub-phase of its turn. To make a Stupidity test, test against the unit’s Leadership characteristic. If this test is failed, the unit becomes Stupid. A Stupid unit:
+•	Moves during the Compulsory Moves sub-phase.
+•	Must move straight ahead, without performing any manoeuvres.
+•	Cannot march or declare a charge.
 A unit or mount that does not have this special rule becomes subject to it when joined or ridden by a character that does (Stupidity is contagious).</characteristic>
       </characteristics>
     </profile>
     <profile name="Swiftstride" hidden="false" id="dc91-48b3-3696-217" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">???</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule increases its maximum possible charge range by 3&quot; and, when it makes a Charge, Flee or Pursuit roll, may apply a +D6 modifier to the result.</characteristic>
       </characteristics>
     </profile>
     <profile name="Terror" hidden="false" id="c7a2-35bf-4313-f4f0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Terror. Models that cause Terror also cause Fear.
-
-- When a unit that causes Terror declares a charge, the charge target must immediately make a Leadership test. If this test is failed, it must Flee. If this test is passed, it can declare its charge reaction normally.
-- If the winning side of a combat includes one or more units that cause Terror, each unit that belongs to the losing side must apply a -1 modifier to its Leadership characteristic when making its Break test.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Terror. Models that cause Terror also cause Fear, as described on page 168:
+•	When a unit that causes Terror declares a charge, the charge target must immediately make a Leadership test. If this test is failed, it must Flee. If this test is passed, it can declare its charge reaction normally.
+•	If the winning side of a combat includes one or more units that cause Terror, each unit that belongs to the losing side must apply a -1 modifier to its Leadership characteristic when making its Break test.
 Note that if a charged unit cannot choose to Flee, it does not make this Leadership test.
-
 Models with the Fear special rule Fear models that cause Terror. Models that cause Terror are immune to Terror. A unit that does not cause Terror does not become immune to Terror when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
     <profile name="Timmm-berrr!" hidden="false" id="4f28-3f86-cf88-6b3a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model is reduced to zero Wounds, the winner of a roll-off choses one of its arcs(front, flank or rear) for it to fall into. Army units that are within the chosen arc and in base contact with this model suffer D6 hits, each using the Strength characteristic of this model with an AP of -1. Once these hits are resolved, this model is removed from play.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model is reduced to zero Wounds, the winner of a roll-off chooses one of its arcs (front, flank or rear) for it to fall into. Any units that are within the chosen arc and in base contact with this model suffer D6 hits, each using the Strength characteristic of this model, with an AP of -1. Once these hits are resolved, this model is removed from play.</characteristic>
       </characteristics>
     </profile>
     <profile name="Unbreakable" hidden="false" id="d3eb-1fa0-bb19-f390" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rile loses a round of combat, it is not required to make a Break test. Instead, it will automatically Give Ground as it is pushed back by the enemy. Characters that are not Unbreakable cannot join units that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule loses a round of combat, it is not required to make a Break test. Instead, it will automatically Give Ground as it is pushed back by the enemy. Characters that are not Unbreakable cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warp-spawned" hidden="false" id="c24d-4386-c1ef-f195" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Magical attack. In addition, characters that are not Warp-spawned cannot join a unit that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Magical attack. In addition, characters that are not Warp-spawned cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Volley Fire" hidden="false" id="330c-821e-8fe0-d4ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this special rile makes a shooting attack, half of the models in each rank other than the front rank (or front two ranks if the unit is on a hill), rounding up, can shoot (in addition to the usual models that shoot from the front rank, or front two ranks if the unit is on a hill). A unit cannot Volley Fire if it has moved for any reason during this turn (including reforming), or when making a Stand &amp; Shoot charge reaction.
-
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this special rule makes a shooting attack, half of the models in each rank other than the front rank (or front two ranks if the unit is on a hill), rounding up, can shoot (in addition to the usual models that shoot from the front rank, or front two ranks if the unit is on a hill). A unit cannot Volley Fire if it has moved for any reason during this turn (including reforming), or when making a Stand &amp; Shoot charge reaction.
 Note that models in rear ranks use the line of sight of the model at the front of their file.</characteristic>
       </characteristics>
     </profile>
     <profile name="Unstable" hidden="false" id="a10e-13b7-e959-ab5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">??????</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule loses a round of combat, it loses one additional Wound for every combat result point by which it lost. These Wounds are lost after combat results have been calculated but before Break tests are made.
+If an Unstable unit contains any Unstable characters, allocate wounds to the unit until each model has been allocated one wound. Any remaining wounds are divided as equally as possible between the character(s) and the unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Standard Bearer" hidden="false" id="bcf8-d942-102e-b155" typeId="52d4-d959-fe4d-90fa" typeName="Command">
@@ -809,9 +799,13 @@ Note that models in rear ranks use the line of sight of the model at the front o
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S6 AP-3 Cumbersome, Move or Shoot, Multiple Wounds (2), Through or Through</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="226" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">48&quot; S8 AP-2 Armour Bane(2), Cannon Fire, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">48&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">8</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Cannon Fire, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Stone Thrower" hidden="false" id="3142-ada8-328d-1615" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -826,17 +820,21 @@ Note that models in rear ranks use the line of sight of the model at the front o
     </profile>
     <profile name="Fire Thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5 AP-1  Column of Fire, Cumbersome, Flaming Attack, Move or Shoot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5 AP-1  Column of Fire, Cumbersome, Flaming Attack, Move or Shoot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S Move &amp; Shoot, Quick Shot</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
     <profile name="Cavalry Spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Fight in Extra Rank. Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A cavalry&apos;s spear Strength and Armor Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Fight in Extra Rank. Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A cavalry&apos;s spear Strength and Armor Piercing modifiers apply only during a turn in which the wielder charged. A model wielding a cavalry spear cannot make a supporting attack during a turn in which it charged.</characteristic>
       </characteristics>
     </profile>
     <profile name="Morning Star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -844,29 +842,49 @@ Note that models in rear ranks use the line of sight of the model at the front o
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 A morning star&apos;s Strength modifier applies only during the first round of combat.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1 AP-1 Armour Bane (1), Requires Two Hands</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flail" hidden="false" id="b326-5bf3-9b4e-f8ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Flail" hidden="false" id="b326-5bf3-9b4e-f8ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Requires Two Hands, A flail&apos;s Strength modifier applies only during the first round of combat.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Fight in Extra Rank, Strike First</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank, Strike First</characteristic>
       </characteristics>
     </profile>
-    <profile name="Lance" hidden="false" id="3520-64c9-a855-ce9e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Lance" hidden="false" id="3520-64c9-a855-ce9e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-2 Armour Bane (1) Models which troop type is &apos;cavalry&apos; or &apos;monster&apos; only. A lance can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Quick Shot, Volley Fire</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">18&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Quick Shot, Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Warbow" hidden="false" id="4ba0-4ae4-3ac2-a173" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -884,9 +902,13 @@ Note that models in rear ranks use the line of sight of the model at the front o
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">24&quot; S4 AP-1 Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">30&quot; S4 Armour Bane (2), Ponderous</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">30&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Ponderous</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -904,9 +926,13 @@ Note that models in rear ranks use the line of sight of the model at the front o
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Sling" hidden="false" id="eee6-7b1-58de-6ad2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Sling" hidden="false" id="eee6-7b1-58de-6ad2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S3 Multiple Shots (2)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">18&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">3</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
     <profile name="Throwing Axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -982,7 +1008,7 @@ Note that models in rear ranks use the line of sight of the model at the front o
     </profile>
     <profile name="Nehekharan Phalanx" hidden="false" id="a527-88cc-ddd6-1ea0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may choose not to Give Ground Should it lose a round in combat. However, if the winning side significantly outnumbers the losing side, it will overwhelm the loser. If the Unit Strength of the winning side is more than twice that of the losing side, the unit cannot use this special rule and must Give Ground as normal.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may choose not to Give Ground Should it lose a round in combat. However, if the winning side significantly outnumbers the losing side, it will overwhelm the loser. If the Unit Strength of the winning side is more than twice that of the losing side, the unit cannot use this special rule and must Give Ground as normal.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -109,6 +109,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Extra Attacks (D3)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="76" publicationId="7c89-736c-3139-24a0">

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -82,9 +82,9 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawn of Nurgle have the Poisoned Attacks special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Two-Headed Dragon" hidden="false" id="8105-d278-5b89-396e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Two-Headed Dragon" hidden="false" id="8105-d278-5b89-396e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="74" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Chaos Dragon may use wither Dark Fire of Chaos or Fumes of Contagion during the Shooting phase of its turn. It cannot use both during the same turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Chaos Dragon may use either Dark Fire of Chaos or Fumes of Contagion during the Shooting phase of its turn. It cannot use both during the same turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Spawn of Tzeentch" hidden="false" id="d3d3-e2a9-b492-9302" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
@@ -102,9 +102,13 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Poisoned Attacks, Strike First. In combat, this model must make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fiend Tail" hidden="false" id="46f5-5901-36ed-cabd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Fiend tail" hidden="false" id="46f5-5901-36ed-cabd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="75" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1 Extra Attacks (D3). In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Extra Attacks (D3)</characteristic>
       </characteristics>
     </profile>
     <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="76" publicationId="7c89-736c-3139-24a0">
@@ -126,9 +130,13 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flaming Breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Flaming breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="75" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Doomfire" hidden="false" id="3b5b-e152-d2cb-99e8" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -59,7 +59,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Troll Vomit" hidden="false" id="2007-796b-3c57-ec28" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 A Chaos Troll that is in base contact with an enemy model may make one additional attack each turn with this weapon. This attack must be made last, after all other attacks have been made (including Stomp Attacks), but hits automatically.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 A Chaos Troll that is in base contact with an enemy model may make one additional attack each turn with this weapon. This attack must be made last, after all other attacks have been made (including Stomp Attacks), but hits automatically.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rampant Mutation" hidden="false" id="f83f-94ab-eab5-46c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="63" publicationId="7c89-736c-3139-24a0">
@@ -109,7 +109,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Fiend Tail" hidden="false" id="46f5-5901-36ed-cabd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-1 Extra Attacks (D3). In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1 Extra Attacks (D3). In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="76" publicationId="7c89-736c-3139-24a0">
@@ -119,22 +119,22 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Fumes of Contagion" hidden="false" id="c74a-5987-c842-d1ef" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon,  Magical Attacks. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon,  Magical Attacks. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Dark Fire of Chaos" hidden="false" id="bd92-12b9-5474-74a2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Flaming Breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S4 Breath Weapon, Flaming Attacks</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Doomfire" hidden="false" id="3b5b-e152-d2cb-99e8" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; 5(10) AP-2(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3). This weapon shoots like a stone thrower, using the &apos;Bombardment&apos; special rule a 3&quot; blast template and the Hellcannon Misfire table. Any unit that suffers one or more unsaved wounds from this weapon must make a Panic test as if it had taken heavy casualties.</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; 5(10) AP-2(-3) Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3). This weapon shoots like a stone thrower, using the &apos;Bombardment&apos; special rule a 3&quot; blast template and the Hellcannon Misfire table. Any unit that suffers one or more unsaved wounds from this weapon must make a Panic test as if it had taken heavy casualties.</characteristic>
       </characteristics>
     </profile>
     <profile name="Wilful Beast" hidden="false" id="1c17-a2e1-fd0a-3714" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="73" publicationId="7c89-736c-3139-24a0">

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -29,7 +29,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Spawn of Slaanesh" hidden="false" id="771c-aa7a-7d32-c9d9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Slaanesh have the Strike First special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawn of Slaanesh have the Strike First special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mark of Chaos Undivided" hidden="false" id="fcf3-41f3-60c8-7deb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -39,7 +39,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Ogre Charge" hidden="false" id="d256-85be-6fcc-1cb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="64" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Armour Piercing characteristic of any Impact Hits caused by a midel with this special rule is improved by the current Rank Bonus of its unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The Armour Piercing characteristic of any Impact Hits caused by a model with this special rule is improved by the current Rank Bonus of its unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mark of Nurgle" hidden="false" id="afeb-3bc4-18-88d7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -64,12 +64,7 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Rampant Mutation" hidden="false" id="f83f-94ab-eab5-46c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="63" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit&apos;s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, roll on the table below to determine which mutation it is currently affected with:
-
-
-- 1-2: Venomous Fangs: With jaws distended, the Forsaken sink venomous fangs into their foes. Until the end of this Combat phase, the unit gains the Poisoned Attacks special rule.
-- 3-4: Razor Talons: With talons like the blades of daggers, the Forsaken slash at their enemies. Until the end of this Combat phase, all of the unit&apos;s attacks have an Armour Piercing characteristic of -2.
-- 5-6: Decapitating Claws: With gigantic snapping claws the Forsaken dismember the enemy. Until the end of this Combat phase, the unit gains the Killing Blow special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, roll on the table below to determine which mutation it is currently afflicted with:</characteristic>
       </characteristics>
     </profile>
     <profile name="Mark of Khorne" hidden="false" id="47ce-619-7fe2-fd08" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -79,12 +74,12 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Spawn of Khorne" hidden="false" id="bc77-5785-84ff-6552" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Khorne have the Killing Blow special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawn of Khorne have the Killing Blow special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Spawn of Nurgle" hidden="false" id="586b-2803-1084-f05e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Nurgle have the Poison Attacks special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawn of Nurgle have the Poisoned Attacks special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Two-Headed Dragon" hidden="false" id="8105-d278-5b89-396e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -94,12 +89,12 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Spawn of Tzeentch" hidden="false" id="d3d3-e2a9-b492-9302" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="66" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawns of Tzeentch have the Flaming Attacks and Magical Attacks special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Spawn of Tzeentch have the Flaming Attacks and Magical Attacks special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Handler" hidden="false" id="e746-bbf6-d1b9-b9c7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="70" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A chaos Warhound Handler is a special type of character that can be taken as an upgrade to accompany a unit of Chaos Warhounds. During deployment, position a Chaos Warhound handler with its unit of Chaos Warhounds, as you would a character that has joined a unit. Once placed, a Chaos Warhound Handler cannot leave the unit. Unless this model is fleeing, friendly units of Chaos Warhounds that are within its Commanding range can use this model&apos;s Leadership instead of their own.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Chaos Warhound Handler is a special type of character that can be taken as an upgrade to accompany a unit of Chaos Warhounds. During deployment, position a Chaos Warhound Handler with its unit of Chaos Warhounds, as you would a character that has joined a unit. Once placed, a Chaos Warhound Handler cannot leave its unit. Unless this model is fleeing, friendly units of Chaos Warhounds that are within its Command range can use this model’s Leadership instead of their own.</characteristic>
       </characteristics>
     </profile>
     <profile name="Venomous Tail" hidden="false" id="9bf7-5630-e483-56df" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -114,17 +109,21 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Caged Fury" hidden="false" id="fa6a-ab7-6580-a1ea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="76" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, make a Leadership test for this model. If this test is failed, roll immediately on the Hellcannon Missfire table.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of your turns, make a Leadership test for this model. If this test is failed, roll immediately on the Hellcannon Misfire table.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fumes of Contagion" hidden="false" id="c74a-5987-c842-d1ef" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon,  Magical Attacks. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon,  Magical Attacks. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dark Fire of Chaos" hidden="false" id="bd92-12b9-5474-74a2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Dark Fire of Chaos" hidden="false" id="bd92-12b9-5474-74a2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="74" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S4 AP-1 Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">4</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
       </characteristics>
     </profile>
     <profile name="Flaming Breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -139,10 +138,8 @@ Note that this special rule may only apply to a single, non-magical hand weapon 
     </profile>
     <profile name="Wilful Beast" hidden="false" id="1c17-a2e1-fd0a-3714" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="73" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of their turns, this model must make a Leadership test (using its own unmodified Leadership). If this test is passed, the rider is able to keep control of their mount. If however, this test is failed, the rider has lost control and their mount becomes subject to the Frenzy special rule until their next Start of Turn sub-phase.
-
-
-Note that this model&apos;s rider does not gain a +1 modifier to their Attacks characteristic.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Start of Turn sub-phase of each of their turns, this model must make a Leadership test (using its own unmodified Leadership). If this test is passed, the rider is able to keep control of their mount. If, however, this test is failed, the rider has lost control and their mount becomes subject to the Frenzy special rule until their next Start of Turn sub-phase.
+Note that this model’s rider does not gain a +1 modifier to their Attacks characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chosen Chaos Warriors" hidden="false" id="3f18-9d0e-3bca-b5ac" typeId="b070-143a-73f-2772" typeName="Model">

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -3,30 +3,29 @@
   <sharedProfiles>
     <profile name="Elven Reflexes" hidden="false" id="a8c1-1eef-eaba-d157" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule (but not its mount) has a +1 modifier to its Initiative characteristic (to a maximum of 10) during the first round of any combat</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule (but not its mount) has a +1 modifier to its Initiative characteristic (to a maximum of 10) during the first round of any combat</characteristic>
       </characteristics>
     </profile>
     <profile name="Talismanic Tattoos" hidden="false" id="2607-d20d-bd9a-871f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Talismanic Tattoos give their wearer a 6+ Ward save against any wounds suffered.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Talismanic Tattoos give their wearer a 6+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
     <profile name="Tree Whack" hidden="false" id="1ca4-df5e-b2e7-9e1e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, during the Combat phase, a model with this special rule may use one of its Attacks to make a single Tree Whack attack. To make a Tree Whack attack, nominate a single model within an enemy unit that this model is engaged in combat
-with to be the target of the attack. That model must immediately make an Initiative test:
-• If the test is failed, the target suffers D3 hits, each using the Strength characteristic of this model with no armour save permitted (Ward and Regeneration saves can be attempted as normal).
-• If the test is passed, the target manages to avoid the Tree Whack.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, during the Combat phase, a model with this special rule may use one of its Attacks to make a single ‘Tree Whack’ attack. To make a Tree Whack attack, nominate a single model within an enemy unit that this model is engaged in combat with to be the target of the attack. That model must immediately make an Initiative test:
+•	If the test is failed, the target suffers D3 hits, each using the Strength characteristic of this model, with no armour save permitted (Ward and Regeneration saves can be attempted as normal).
+•	If the test is passed, the target manages to avoid the Tree Whack.</characteristic>
       </characteristics>
     </profile>
     <profile name="Tree Spirit" hidden="false" id="73e-df40-cff9-91af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot join a unit without this special rule. A unit with this special rule cannot be joined by or use the Leadership characteristic of a character without this special rule. However, a unit with this special rule can use the Leadership characteristic of a friendly character with this special rule that is not fleeing whilst within that character’s Command range.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot join a unit without this special rule. A unit with this special rule cannot be joined by, or use the Leadership characteristic of, a character without this special rule. However, a unit with this special rule can use the Leadership characteristic of a friendly character with this special rule that is not fleeing whilst within that character’s Command range.</characteristic>
       </characteristics>
     </profile>
     <profile name="Woodland Ambush" hidden="false" id="954c-58d2-3702-51c3" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="145" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once players have finished placing terrains, a Wood Elf Realms player may place one additional wood measuring between 8’’ and 12’’ at its widest point. This may be placed anywhere on the battlefield that is not within their opponent&apos;s deployment zone and not within 12’’ of the centre of the battlefield.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once players have finished placing terrain, a Wood Elf Realms player may place one additional wood measuring between 8&quot; and 12&quot; at its widest point. This may be placed anywhere on the battlefield that is not within their opponent’s deployment zone and not within 12&quot; of the centre of the battlefield.</characteristic>
       </characteristics>
     </profile>
     <profile name="Glade Guard" hidden="false" id="c620-c9a4-77e5-a99" typeId="b070-143a-73f-2772" typeName="Model">
@@ -112,7 +111,7 @@ charged. During a turn in which it was charged in its front arc, a model wieldin
     </profile>
     <profile name="Guardians Of The Wildwood" hidden="false" id="ee3d-981c-3be0-7aef" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="130" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst it is on base contact with an enemy model that causes Fear or Terror, a model with this special rule gains a +1 modifier to its Attacks characteristics (to a maximum of 10) and the Multiple Wounds (2) special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst it is in base contact with an enemy model that causes Fear or Terror, a model with this special rule gains a +1 modifier to its Attacks characteristics (to a maximum of 10) and the Multiple Wounds (2) special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Wardancers" hidden="false" id="6518-8fc0-d3e3-5158" typeId="b070-143a-73f-2772" typeName="Model">
@@ -241,9 +240,13 @@ Notes: In combat, this model must make one of its attacks each turn with this we
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP2</characteristic>
       </characteristics>
     </profile>
-    <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, AP1, Multiple Shots (D6+1)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">12&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Multiple Shots (D6+1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Glade Lord" hidden="false" id="f342-d4ec-ea35-fbc1" typeId="b070-143a-73f-2772" typeName="Model">
@@ -456,7 +459,7 @@ Notes: In combat, this model must make one of its attacks each turn with this we
     </profile>
     <profile name="The Arrow Of Kurnous" hidden="false" id="9e77-e167-9d98-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="120" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once deployment is complete, but before the roll-off to determine which player takes the first turn, if the General of your opponent army is withing 36&quot; of one or more models of your army that has this special rule, one of those models may fire the Arrow of Kurnous. If the Arrow of Kurnous is fired, the General of your opponent&apos;s army inmediatly suffer a single Streght 3 hit, with no armour or Regeneration saves permitted (Ward saves can be attempted as normal).
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once deployment is complete, but before the roll-off to determine which player takes the first turn, if the General of your opponent’s army is within 36&quot; of one or more models in your army that has this special rule, one of those models may fire the Arrow of Kurnous. If the Arrow of Kurnous is fired, the General of your opponent’s army immediately suffers a single Strength 3 hit, with no armour or Regeneration saves permitted (Ward saves can be attempted as normal).
 However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll when rolling off to determine who takes the first turn.</characteristic>
       </characteristics>
     </profile>
@@ -465,9 +468,13 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Shadowdancer that joins a unit of Wardancers is considered to have the Dances of Loec special rule for as long as they remains with the unit</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="122" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP1, Armour Bane (2), Killing Blow</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (2), Killing Blow</characteristic>
       </characteristics>
     </profile>
     <profile name="Trickater&apos;s Blades" hidden="false" id="205a-ad0c-c943-54f6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -477,12 +484,12 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Hawk-eyed Archer" hidden="false" id="f229-4b9d-faba-7568" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="123" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule can target any enemy character it can draw a line of sight to, regardless of the usual rules for targeting Lone characters. In addition, a model with this special rule can target a specific model withing its target unit, such as a champion or a character.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule can target any enemy character it can draw a line of sight to, regardless of the usual rules for targeting Lone characters. In addition, a model with this special rule can target a specific model within its target unit, such as a champion or a character.</characteristic>
       </characteristics>
     </profile>
     <profile name="Crown Of Antlers" hidden="false" id="d43d-b899-cd36-9ba7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="126" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have the Armour Bane (1) special ruleand an Armour Piercing characteristic of -1</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have the Armour Bane (1) special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mighty Antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -523,7 +530,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Daughters Of Eternity" hidden="false" id="2eab-a965-2f01-1b5b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="135" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 4+ Ward save against any wound suffered.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This unit has a 4+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
     <profile name="Deepwood Covern" hidden="false" id="39d9-c621-bd14-c720" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -560,22 +567,22 @@ with Arcane Bodkins has an AP of -2.</characteristic>
     </profile>
     <profile name="Hagbane Tips" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="e225-f313-d494-fd74">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Even a scratch from an arrow dipped in Hagbane sap can prove fatal. An Asrai Longbow with Hagbane Tips has the Poisoned Attacks special rule</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Even a scratch from an arrow dipped in Hagbane sap can prove fatal. An Asrai Longbow with Hagbane Tips has the Poisoned Attacks special rule</characteristic>
       </characteristics>
     </profile>
     <profile name="Moonfire Shot" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="f8d1-e254-62cc-20e8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Glowing eerily with pale light, the touch of these arrows bring searing agony. An Asrai Longbow with the Moonfire Shot has the Flaming Attacks and Magical Attacks special rules.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Glowing eerily with pale light, the touch of these arrows bring searing agony. An Asrai Longbow with the Moonfire Shot has the Flaming Attacks and Magical Attacks special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Swiftshiver Shards" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="7239-1d57-a7fd-939e">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">These arrows seems to fly from the bow of their own accord. An Asrai Longbow with the Swiftshiver Shards has the Multiple Shots (2) special rule</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">These arrows seems to fly from the bow of their own accord. An Asrai Longbow with the Swiftshiver Shards has the Multiple Shots (2) special rule</characteristic>
       </characteristics>
     </profile>
     <profile name="Trueflight Arrows" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="bc20-ac7-f6db-fe64">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">These enchanted arrows seek out their targets with unerring accuracy. An Asrai Longbow with Trueflight Arrows has the Ignores Covers and Quick Shot special rules.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">These enchanted arrows seek out their targets with unerring accuracy. An Asrai Longbow with Trueflight Arrows has the Ignores Covers and Quick Shot special rules.</characteristic>
       </characteristics>
     </profile>
     <profile name="Great Eagles Mount" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="c174-785d-1224-a36">

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -44,12 +44,12 @@ with to be the target of the attack. That model must immediately make an Initia
     </profile>
     <profile name="Asrai Longbow" hidden="false" id="52f0-5d10-bf38-7541" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">32&quot; S5 , Armour Bane (1), Volley Fire</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">32&quot; S5 , Armour Bane (1), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Enchanted Arrows" hidden="false" id="da29-8223-a95d-8407" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9"/>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9"/>
       </characteristics>
     </profile>
     <profile name="Deepwood Scouts" hidden="false" id="84a6-b6-84a6-2b8" typeId="b070-143a-73f-2772" typeName="Model">
@@ -85,7 +85,7 @@ with to be the target of the attack. That model must immediately make an Initia
     </profile>
     <profile name="Asrai Spear" hidden="false" id="4338-1ef3-1095-9080" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP1, Fight in Extra Rank
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1, Fight in Extra Rank
 
 Notes: A model wielding an Asrai spear cannot make a supporting attack during a turn in which it
 charged. During a turn in which it was charged in its front arc, a model wielding an Asrai spear gains a
@@ -107,7 +107,7 @@ charged. During a turn in which it was charged in its front arc, a model wieldin
     </profile>
     <profile name="Ranger&apos;s Glaive" hidden="false" id="10ef-7481-e2ba-547" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2, AP-2, Requires Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+2, AP-2, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Guardians Of The Wildwood" hidden="false" id="ee3d-981c-3be0-7aef" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="130" publicationId="8b8d-8fc4-559e-87b1">
@@ -196,18 +196,18 @@ Note that a Shadowdancer that joins this unit is considered to have this special
     </profile>
     <profile name="Wicked Claws" hidden="false" id="3e22-4ea4-405d-a8ac" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S, Ap-2</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S, Ap-2</characteristic>
       </characteristics>
     </profile>
     <profile name="Serrated Maw" hidden="false" id="76ad-9eb5-36f5-d56e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S, Armour Bane (2), Multiple Wounds (2)
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S, Armour Bane (2), Multiple Wounds (2)
 Notes: In combat, this model must make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
     <profile name="Soporific Breath" hidden="false" id="8d45-3cca-ff3-20f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2, Breath Weapon</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2, Breath Weapon</characteristic>
       </characteristics>
     </profile>
     <profile name="Great Eagles" hidden="false" id="cab1-94a3-97aa-dde" typeId="b070-143a-73f-2772" typeName="Model">
@@ -238,12 +238,12 @@ Notes: In combat, this model must make one of its attacks each turn with this we
     </profile>
     <profile name="Oaken Fists" hidden="false" id="6130-5aa6-5297-80c2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP2</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP2</characteristic>
       </characteristics>
     </profile>
     <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, AP1, Multiple Shots (D6+1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot;, AP1, Multiple Shots (D6+1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Glade Lord" hidden="false" id="f342-d4ec-ea35-fbc1" typeId="b070-143a-73f-2772" typeName="Model">
@@ -467,12 +467,12 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP1, Armour Bane (2), Killing Blow</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP1, Armour Bane (2), Killing Blow</characteristic>
       </characteristics>
     </profile>
     <profile name="Trickater&apos;s Blades" hidden="false" id="205a-ad0c-c943-54f6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Attacks (+D3), Require Two Hands</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">Extra Attacks (+D3), Require Two Hands</characteristic>
       </characteristics>
     </profile>
     <profile name="Hawk-eyed Archer" hidden="false" id="f229-4b9d-faba-7568" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="123" publicationId="8b8d-8fc4-559e-87b1">
@@ -487,7 +487,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Mighty Antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-1, Armour Bane (1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1, Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Beguiling Aura" hidden="false" id="a71and Ambush4-9173-806f-c32d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -505,7 +505,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Blackbriar Javelines" hidden="false" id="5a44-f24a-a1fa-e3c1" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5, AP-1 , Move &amp; Shoot, Quick Shoot</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5, AP-1 , Move &amp; Shoot, Quick Shoot</characteristic>
       </characteristics>
     </profile>
     <profile name="Steeds of Isha" hidden="false" id="26bb-2c02-647a-e735" typeId="b070-143a-73f-2772" typeName="Model">
@@ -549,7 +549,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
     </profile>
     <profile name="Hunting Spear" hidden="false" id="5df6-55ba-e648-e1b5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
       <characteristics>
-        <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP-2 , Armour Bane (1)</characteristic>
+        <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP-2 , Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Arcane Bodkins" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="fbe7-82b5-e962-7f13">

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -41,9 +41,13 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">8</characteristic>
       </characteristics>
     </profile>
-    <profile name="Asrai Longbow" hidden="false" id="52f0-5d10-bf38-7541" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Asrai longbow" hidden="false" id="52f0-5d10-bf38-7541" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="147" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">32&quot; S5 , Armour Bane (1), Volley Fire</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">32&quot;</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1), Volley Fire</characteristic>
       </characteristics>
     </profile>
     <profile name="Enchanted Arrows" hidden="false" id="da29-8223-a95d-8407" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
@@ -82,13 +86,17 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can make supporting attacks to its flank or rear, as well as to its front</characteristic>
       </characteristics>
     </profile>
-    <profile name="Asrai Spear" hidden="false" id="4338-1ef3-1095-9080" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Asrai spear" hidden="false" id="4338-1ef3-1095-9080" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="129" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP1, Fight in Extra Rank
 
 Notes: A model wielding an Asrai spear cannot make a supporting attack during a turn in which it
 charged. During a turn in which it was charged in its front arc, a model wielding an Asrai spear gains a
 +1 modifier to its Initiative against the charging unit(s)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
     <profile name="Wildwood Rangers" hidden="false" id="11e8-9cf0-bee3-4de2" typeId="b070-143a-73f-2772" typeName="Model">
@@ -127,18 +135,14 @@ charged. During a turn in which it was charged in its front arc, a model wieldin
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">8</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dances of Loec" hidden="false" id="6630-29b8-8574-30d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Dances of Loec" hidden="false" id="6630-29b8-8574-30d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="131" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, choose one
-of the following Dances of Loec for it to perform. Every model within the unit performs the same Dance:
-• Whirling Death: Until the end of this Combat phase, the Armour Piercing characteristic of this unit’s
-weapons is improved by 2.
-• Storm of Blades: Until the end of this Combat phase, this unit gains the Extra Attacks (+1) special rule.
-• The Shadows Coil: Until the end of this Combat phase, this unit has a 4+ ward save against any
-wounds suffered.
-• Woven Mist: Any enemy model that directs its attacks against this unit during this Combat phase
-suffers a -1 modifier to its rolls To Hit.
-Note that a Shadowdancer that joins this unit is considered to have this special rule as well</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this unit’s combat is chosen during Step 1.1 of any Choose &amp; Fight Combat sub-phase, choose one of the following Dances of Loec for it to perform. Every model within the unit performs the same Dance:
+•	Whirling Death: Until the end of this Combat phase, the Armour Piercing characteristic of this unit’s weapons is improved by 2.
+•	Storm of Blades: Until the end of this Combat phase, this unit gains the Extra Attacks (+1) special rule.
+•	The Shadows Coil: Until the end of this Combat phase, this unit has a 4+ ward save against any wounds suffered.
+•	Woven Mist: Any enemy model that directs its attacks against this unit during this Combat phase suffers a -1 modifier to its rolls To Hit.
+Note that a Shadowdancer that joins this unit is considered to have this special rule as well.</characteristic>
       </characteristics>
     </profile>
     <profile name="Waywatchers" hidden="false" id="5fd6-e1-bd4a-9ef3" typeId="b070-143a-73f-2772" typeName="Model">
@@ -204,9 +208,13 @@ Note that a Shadowdancer that joins this unit is considered to have this special
 Notes: In combat, this model must make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Soporific Breath" hidden="false" id="8d45-3cca-ff3-20f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Soporific breath" hidden="false" id="8d45-3cca-ff3-20f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="138" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S2, Breath Weapon</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">N/A</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">2</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">N/A</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon</characteristic>
       </characteristics>
     </profile>
     <profile name="Great Eagles" hidden="false" id="cab1-94a3-97aa-dde" typeId="b070-143a-73f-2772" typeName="Model">
@@ -235,9 +243,13 @@ Notes: In combat, this model must make one of its attacks each turn with this we
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Oaken Fists" hidden="false" id="6130-5aa6-5297-80c2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Oaken fists" hidden="false" id="6130-5aa6-5297-80c2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP2</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">-</characteristic>
       </characteristics>
     </profile>
     <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="8b8d-8fc4-559e-87b1">
@@ -463,9 +475,9 @@ Notes: In combat, this model must make one of its attacks each turn with this we
 However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll when rolling off to determine who takes the first turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Troubadour of Loec" hidden="false" id="c674-9774-b6f6-cc13" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
+    <profile name="Troubadour of Loec" hidden="false" id="c674-9774-b6f6-cc13" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="122" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Shadowdancer that joins a unit of Wardancers is considered to have the Dances of Loec special rule for as long as they remains with the unit</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Shadowdancer that joins a unit of Wardancers is considered to have the Dances of Loec special rule for as long as they remain with the unit (see page 131).</characteristic>
       </characteristics>
     </profile>
     <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="122" publicationId="8b8d-8fc4-559e-87b1">
@@ -492,9 +504,13 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have the Armour Bane (1) special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Mighty Antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Mighty antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="126" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">AP-1, Armour Bane (1)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Beguiling Aura" hidden="false" id="a71and Ambush4-9173-806f-c32d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -554,9 +570,13 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72"/>
       </characteristics>
     </profile>
-    <profile name="Hunting Spear" hidden="false" id="5df6-55ba-e648-e1b5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Hunting spear" hidden="false" id="5df6-55ba-e648-e1b5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="136" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Free-Text Description" typeId="47f2-ecee-cae0-9ef9">S+1, AP-2 , Armour Bane (1)</characteristic>
+        <characteristic name="R" typeId="b3d5-9c7e-fbc8-bd67">Combat</characteristic>
+        <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
+        <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
+        <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
     <profile name="Arcane Bodkins" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="fbe7-82b5-e962-7f13">

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -97,6 +97,7 @@ charged. During a turn in which it was charged in its front arc, a model wieldin
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-1</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Fight in Extra Rank</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A model wielding an Asrai spear cannot make a supporting attack during a turn in which it charged. During a turn in which it was charged in its front arc, a model wielding an Asrai spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
       </characteristics>
     </profile>
     <profile name="Wildwood Rangers" hidden="false" id="11e8-9cf0-bee3-4de2" typeId="b070-143a-73f-2772" typeName="Model">
@@ -215,6 +216,7 @@ Notes: In combat, this model must make one of its attacks each turn with this we
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">2</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">N/A</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Breath Weapon</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">No armour save is permitted against wounds caused by soporific breath (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
     <profile name="Great Eagles" hidden="false" id="cab1-94a3-97aa-dde" typeId="b070-143a-73f-2772" typeName="Model">
@@ -577,6 +579,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="S" typeId="4a75-6e2c-f91d-326c">S+1</characteristic>
         <characteristic name="AP" typeId="dda4-3a19-9dfd-2c67">-2</characteristic>
         <characteristic name="Special Rules" typeId="21d6-681a-a3ec-cce4">Armour Bane (1)</characteristic>
+        <characteristic name="Notes" typeId="1f46-f4c3-16e1-c349">A hunting spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.</characteristic>
       </characteristics>
     </profile>
     <profile name="Arcane Bodkins" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="fbe7-82b5-e962-7f13">


### PR DESCRIPTION
Fixes a lot of minor discrepancies and typos. 

Add weapon characteristics and auto-populate the profiles. Don't delete the free-text description just yet.

Strip NBSP