### PR TITLE
Fix special rules, change old weapons to "weapons, free-text"

### DIFF
--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -71,12 +71,12 @@ Each time an enemy model is removed from play in this way, the Ghorgon recovers 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">For each Wound this model loses during the Combat phase, the attacking enemy unit suffers a Strength 4 hit, with an AP of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wicked Claws" hidden="false" id="7f7e-dcdb-43fe-ea61" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Wicked Claws" hidden="false" id="7f7e-dcdb-43fe-ea61" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2</characteristic>
       </characteristics>
     </profile>
-    <profile name="Slythey Tongue" hidden="false" id="3e50-c9fe-dc8e-163d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="105" publicationId="7c89-736c-3139-24a0">
+    <profile name="Slythey Tongue" hidden="false" id="3e50-c9fe-dc8e-163d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="105" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot;	S: 5	AP: -1	Special Rules: Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
@@ -86,13 +86,13 @@ Each time an enemy model is removed from play in this way, the Ghorgon recovers 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">At the start of each Combat phase, enemy models in base contact with this model must make an Initiative test. If this test is failed, they suffer D3 Strength 2 hits, with no armour save permitted (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Petrifying Gaze" hidden="false" id="232-9631-9864-6533" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="7c89-736c-3139-24a0">
+    <profile name="Petrifying Gaze" hidden="false" id="232-9631-9864-6533" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="140" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 18&quot;	S: 2	AP: N/A	
 Notes: When making a roll To Wound for an attack made with this weapon, substitute the target’s Toughness with its Initiative. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).	Special Rules: Magical Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Acidic Vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="106" publicationId="7c89-736c-3139-24a0">
+    <profile name="Acidic Vomit" hidden="false" id="5e52-73da-ce6a-c63e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="106" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 3	AP: -1	Special Rules: Breath Weapon</characteristic>
       </characteristics>
@@ -107,12 +107,12 @@ Notes: When making a roll To Wound for an attack made with this weapon, substitu
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any enemy Wizard that wishes to cast a spell whilst within 12&quot; of one or more Cygors must first make a Leadership test. If this test is failed, the Wizard has lost their nerve and, should they fail to cast the spell (i.e., should their casting result be less than the casting value of the spell), the spell has been miscast and the active player immediately rolls on the Miscast table to see what fate befalls the unfortunate Wizard. If this test is passed, the Wizard can continue with their casting attempt as normal.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Hurl Attacks" hidden="false" id="4ae-a68d-e8bd-fc60" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Hurl Attacks" hidden="false" id="4ae-a68d-e8bd-fc60" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-36&quot; S4(8), AP-1(-3), Bombardment, Cumbersome, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cleaver-limber" hidden="false" id="8f70-96a3-fd2b-4bc2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Cleaver-limber" hidden="false" id="8f70-96a3-fd2b-4bc2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5, AP -2, Killing Blow, Monster Slayer</characteristic>
       </characteristics>

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -117,7 +117,7 @@ Note that a Field Trebuchet can still pivot freely at any time during its turn, 
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit that contains a model equipped with a Blessed Triptych gains the Stubborn special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Polearm" hidden="false" id="1f2e-63ae-b4e4-c501" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Polearm" hidden="false" id="1f2e-63ae-b4e4-c501" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Single handed: Fight in Extra Rank
 Double handed: S+1 AP1 Requires Two Hands</characteristic>
@@ -161,7 +161,7 @@ The Grail Reliquae counts as both a standard bearer and a musician for its unit.
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst in Skirmish formation, every model in a unit of Pegasus Knights must be within 2&quot; of another model belonging to the same unit, rather than the usual 1&quot;.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Field Trebuchet" hidden="false" id="948b-a40d-9586-fb3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Field Trebuchet" hidden="false" id="948b-a40d-9586-fb3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-72&quot; S5(10) AP-1(-4) Bombardment, Cumbersome, Immovable Object, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
       </characteristics>

--- a/Chaos Dwarfs.cat
+++ b/Chaos Dwarfs.cat
@@ -671,8 +671,8 @@ Note that this modifier does not apply to mounted characters.</characteristic>
         <characteristic name="R" typeId="2360-c777-5e07-ed58">6&quot;</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">3</characteristic>
         <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-</characteristic>
-        <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Flaming Attacks, Ponderous, Quick Shot</characteristic>
-        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">If the roll To Hit is successful, a naptha bomb causes D3+1 hits to the target enemy unit, rather than the usual one.</characteristic>
+        <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Flaming Attacks, Ponderous, Quick Shot</characteristic>
+        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">If the roll To Hit is successful, a naptha bomb causes D3+1 hits to the target enemy unit, rather than the usual one.</characteristic>
       </characteristics>
     </profile>
     <profile name="Hailshot Blunderbuss" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="51c4-9e27-e574-f438">

--- a/Common Magic Items.cat
+++ b/Common Magic Items.cat
@@ -4996,17 +4996,17 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Laurels of Victory" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items" hidden="false" id="7da2-85b7-871f-c436">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">When determining your combat result, each unsaved wound caused by an attack made by the bearer of the Laurels of Victory is worth 2 combat result points, rather than the usual 1.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">When determining your combat result, each unsaved wound caused by an attack made by the bearer of the Laurels of Victory is worth 2 combat result points, rather than the usual 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Silver Horn" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items" hidden="false" id="1f40-b521-ca01-255c">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Characters with the Swiftstride special rule only. The bearer of the Silver Horn (and any unit they have joined) may re-roll the D6 when using the Swiftstride special rule.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">Characters with the Swiftstride special rule only. The bearer of the Silver Horn (and any unit they have joined) may re-roll the D6 when using the Swiftstride special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Shroud of Iron" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items" hidden="false" id="1338-e796-cf74-9932">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">The bearer of the Shroud of Iron (and any unit they have joined) has a 6+ Ward save against any wounds suffered that were caused by a non-magical template.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">The bearer of the Shroud of Iron (and any unit they have joined) has a 6+ Ward save against any wounds suffered that were caused by a non-magical template.</characteristic>
       </characteristics>
     </profile>
     <profile name="Book of Ashur" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items" hidden="false" id="3dd7-88c9-9f93-b76c">
@@ -5021,22 +5021,22 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Wizard&apos;s Staff" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items" hidden="false" id="74d8-751e-64d6-eeb">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">The bearer of the Wizard’s Staff gains a +1 modifier to their Casting roll when attempting to cast an Assailment spell or a Magic Missile.</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">The bearer of the Wizard’s Staff gains a +1 modifier to their Casting roll when attempting to cast an Assailment spell or a Magic Missile.</characteristic>
       </characteristics>
     </profile>
     <profile name="Trollhide Trousers" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour" hidden="false" id="bded-b681-6a64-5d7e" publicationId="7c89-736c-3139-24a0" page="43">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">May be worn with other armour. The wearer of the Trollhide Trousers improves their armour value by 1 (to a maximum of 2+). In  addition, their wearer has the Regeneration (5+) special rule.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">May be worn with other armour. The wearer of the Trollhide Trousers improves their armour value by 1 (to a maximum of 2+). In  addition, their wearer has the Regeneration (5+) special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Armour of Mork" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour" hidden="false" id="795f-b5dd-1f7e-89fc" publicationId="7c89-736c-3139-24a0" page="43">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Armour of Mork is a suit of heavy armour. In addition, its wearer has Magic Resistance (-2).</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Armour of Mork is a suit of heavy armour. In addition, its wearer has Magic Resistance (-2).</characteristic>
       </characteristics>
     </profile>
     <profile name="’Eadbuttin’ &apos;At" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items" hidden="false" id="75aa-c508-4104-5416">
       <characteristics>
-        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">An ’Eadbuttin’ ’At gives its wearer the Impact Hits (1) special rule. This Impact Hit has an Armour Piercing characteristic of -2.</characteristic>
+        <characteristic name="Description" typeId="cea7-7573-475d-cc1d">An ’Eadbuttin’ ’At gives its wearer the Impact Hits (1) special rule. This Impact Hit has an Armour Piercing characteristic of -2.</characteristic>
       </characteristics>
     </profile>
     <profile name="Big Boss &apos;At" typeId="d29c-a3fb-dcdf-29d6" typeName="Enchanted Items" hidden="false" id="7f06-5327-1717-dfd8">
@@ -5056,12 +5056,12 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="Buzgob’s Knobbly Staff" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items" hidden="false" id="8582-a8c5-4c00-f9e5">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Once per turn, the bearer of the Buzgob’s Knobbly Staff may re-roll a Casting roll.</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">Once per turn, the bearer of the Buzgob’s Knobbly Staff may re-roll a Casting roll.</characteristic>
       </characteristics>
     </profile>
     <profile name="Idol of Mork" typeId="65d6-7512-2a53-bd6c" typeName="Arcane Items" hidden="false" id="eadd-e838-ad31-76d">
       <characteristics>
-        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">The bearer of the Idol of Mork increases their Dispel range by 3&quot;. Additionally, once per turn, when attempting a Wizardly dispel, the bearer of the Idol of Mork may re-roll the Dispel roll.</characteristic>
+        <characteristic name="Description" typeId="fdd8-b367-1d68-c9cd">The bearer of the Idol of Mork increases their Dispel range by 3&quot;. Additionally, once per turn, when attempting a Wizardly dispel, the bearer of the Idol of Mork may re-roll the Dispel roll.</characteristic>
       </characteristics>
     </profile>
     <profile name="Frostblade" hidden="false" id="412b-ca0b-2e5c-71f" typeId="e4d1-790a-ab75-2b57" typeName="Magic Weapons">
@@ -5102,42 +5102,42 @@ When making a roll To Wound for a hit caused with the Sword of Heroes, a roll of
     </profile>
     <profile name="The Flayed Hauberk" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour" hidden="false" id="1441-8731-bf55-389d">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Flayed Hauberk is a suit of heavy armour which may be worn by a Wizard without penalty. In addition, its wearer has a 6+ Ward save against any wounds suffered.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">The Flayed Hauberk is a suit of heavy armour which may be worn by a Wizard without penalty. In addition, its wearer has a 6+ Ward save against any wounds suffered.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Accursed Armour" typeId="fefe-6a57-a203-edf9" typeName="Magic Armour" hidden="false" id="3c9c-bf4c-328c-785">
       <characteristics>
-        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">Models whose troop type is ‘infantry’ or ‘cavalry’ only. The Accursed Armour is a suit of full plate armour. In addition, its wearer has a +1 modifier to their Toughness characteristic, but suffers a -1 modifier to their Weapon Skill and Initiative characteristics.</characteristic>
+        <characteristic name="Description" typeId="d6b2-9b2a-d88e-eec9">Models whose troop type is ‘infantry’ or ‘cavalry’ only. The Accursed Armour is a suit of full plate armour. In addition, its wearer has a +1 modifier to their Toughness characteristic, but suffers a -1 modifier to their Weapon Skill and Initiative characteristics.</characteristic>
       </characteristics>
     </profile>
     <profile name="Crown Of The Damned" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans" hidden="false" id="7dc1-49c7-8ec0-d734">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The Crown of the Damned gives its wearer a 4+ Ward save against any wounds suffered. However, due to the wailing of the spirits trapped within the crown, its wearer is also subject to the Stupidity special rule.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">The Crown of the Damned gives its wearer a 4+ Ward save against any wounds suffered. However, due to the wailing of the spirits trapped within the crown, its wearer is also subject to the Stupidity special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Von Carstein Ring" typeId="5c1d-13f3-7dd6-e817" typeName="Talismans" hidden="false" id="86e5-6230-eda5-c9a">
       <characteristics>
-        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Vampires only. Single use. When the wearer of the Von Carstein Ring loses their last Wound, roll a D6. On a roll of 2+, the Wound is not lost.</characteristic>
+        <characteristic name="Description" typeId="3fa5-c856-b00a-c9f4">Vampires only. Single use. When the wearer of the Von Carstein Ring loses their last Wound, roll a D6. On a roll of 2+, the Wound is not lost.</characteristic>
       </characteristics>
     </profile>
     <profile name="Standard Of Hellish Vigour." typeId="e3be-1b80-f570-96a1" typeName="Magic Standards" hidden="false" id="7fc8-4ac1-5a59-a419">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">A unit carrying the Standard of Hellish Vigour gains the Reserve Move special rule.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">A unit carrying the Standard of Hellish Vigour gains the Reserve Move special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Banner Of The Barrows" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards" hidden="false" id="f05c-5ba4-2539-5818">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Wight Lord Battle Standard Bearer only. During the Combat phase, when a unit carrying the Banner of the Barrows makes a roll To Hit, a roll of 3+ is always a success, regardless of the target’s Weapon Skill.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">Wight Lord Battle Standard Bearer only. During the Combat phase, when a unit carrying the Banner of the Barrows makes a roll To Hit, a roll of 3+ is always a success, regardless of the target’s Weapon Skill.</characteristic>
       </characteristics>
     </profile>
     <profile name="Drakenhof Banner" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards" hidden="false" id="61ee-bfae-1ea0-7903">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">If a unit carrying the Drakenhof Banner has the Regeneration (X+) special rule, it improves the armour value of its Regeneration save by 1.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">If a unit carrying the Drakenhof Banner has the Regeneration (X+) special rule, it improves the armour value of its Regeneration save by 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Screaming Banner" typeId="e3be-1b80-f570-96a1" typeName="Magic Standards" hidden="false" id="31fa-2f6b-dfe0-f253">
       <characteristics>
-        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">When an enemy unit makes a Leadership test due to Fear caused by a unit carrying the Screaming Banner, it must roll an extra D6 and discard the lowest result.</characteristic>
+        <characteristic name="Description" typeId="a34c-cc25-6cb9-95e1">When an enemy unit makes a Leadership test due to Fear caused by a unit carrying the Screaming Banner, it must roll an extra D6 and discard the lowest result.</characteristic>
       </characteristics>
     </profile>
     <profile name="The Graven Sceptre" hidden="false" id="1e7b-7a42-195-94c5" typeId="e4d1-790a-ab75-2b57" typeName="Magic Weapons">

--- a/Daemons of Chaos.cat
+++ b/Daemons of Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ec01-a361-b3bf-78ac" name="Daemons of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="8" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Giloushaker#2496">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="ec01-a361-b3bf-78ac" name="Daemons of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="8" battleScribeVersion="2.03" type="catalogue" authorContact="Giloushaker#2496">
   <sharedProfiles>
     <profile name="Bloodthirster" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="2304-f7d1-ef2a-eb19">
       <characteristics>
@@ -1018,7 +1018,7 @@ unit’s current Rank Bonus.</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">S</characteristic>
         <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-1</characteristic>
         <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Multiple Wounds (D3)</characteristic>
-        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">The Multiple Wounds (D3) special rule only applies against enemy models whose troop type is ‘monster’</characteristic>
+        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">The Multiple Wounds (D3) special rule only applies against enemy models whose troop type is ‘monster’</characteristic>
       </characteristics>
     </profile>
     <profile name="Venomous tail" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="c2dd-e3b2-645e-f01b">
@@ -2861,7 +2861,7 @@ Quick Shot</characteristic>
                 <profile name="Plague Proboscis" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c3c5-aaf4-9bc7-684f">
                   <characteristics>
                     <characteristic name="Description" typeId="9f84-4221-785a-db50">+1 Initiative
-The Initiative modifier applies only to the Rot Flies, not to their riders.</characteristic>
+The Initiative modifier applies only to the Rot Flies, not to their riders.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -6443,7 +6443,7 @@ The Initiative modifier applies only to the Rot Flies, not to their riders.</ch
                     <characteristic name="R" typeId="2360-c777-5e07-ed58">Combat</characteristic>
                     <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">S+1</characteristic>
                     <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-1</characteristic>
-                    <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Killing Blow, Magical Attacks, Requires Two Hands</characteristic>
+                    <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Killing Blow, Magical Attacks, Requires Two Hands</characteristic>
                     <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
                   </characteristics>
                 </profile>
@@ -6489,7 +6489,7 @@ The Initiative modifier applies only to the Rot Flies, not to their riders.</ch
               <profiles>
                 <profile name="Collar Of Khorne*" typeId="7880-d24a-41cd-e646" typeName="Daemonic Gifts" hidden="false" id="3126-899e-b626-ed55">
                   <characteristics>
-                    <characteristic name="Description" typeId="3f73-d64e-43fa-7d1b">The wearer of a Collar of Khorne improves its Magic Resistance by 1. 
+                    <characteristic name="Description" typeId="3f73-d64e-43fa-7d1b">The wearer of a Collar of Khorne improves its Magic Resistance by 1. 
 For example, a model with Magic Resistance (-2) wearing a Collar of Khorne would have Magic Resistance (-3).</characteristic>
                   </characteristics>
                 </profile>
@@ -6950,12 +6950,12 @@ That enemy unit must make a Leadership test. If this test is passed, the unit ma
             <characteristic name="Type" typeId="c2ca-5fd1-5e9d-bc90">Hex</characteristic>
             <characteristic name="Casting Value" typeId="d84d-3b8b-654a-9e1a">8+/12+</characteristic>
             <characteristic name="Range" typeId="1043-a0ad-2909-dd28">12&quot;</characteristic>
-            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If this spell is cast with a casting result of 8 or more, the target enemy unit suffers a -D3 modifier to one of the following characteristics (to a minimum of 1, chosen by the casting player). 
-If this spell is cast with a casting result of 12 or more, the target enemy unit suffers a -D3 modifier to two of the following characteristics (to a minimum of 1, chosen by the casting player). 
+            <characteristic name="Effect" typeId="64ba-31-acf0-5a">If this spell is cast with a casting result of 8 or more, the target enemy unit suffers a -D3 modifier to one of the following characteristics (to a minimum of 1, chosen by the casting player). 
+If this spell is cast with a casting result of 12 or more, the target enemy unit suffers a -D3 modifier to two of the following characteristics (to a minimum of 1, chosen by the casting player). 
 This spell lasts until your next Start of Turn sub-phase:
- • Weapon Skill
- • Strength
- • Toughness</characteristic>
+ • Weapon Skill
+ • Strength
+ • Toughness</characteristic>
           </characteristics>
           <modifiers>
             <modifier type="set" value="true" field="hidden">

--- a/Dark Elves.cat
+++ b/Dark Elves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="d9b0-fa44-a251-bfea" name="Dark Elves" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Giloushaker#2496">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="d9b0-fa44-a251-bfea" name="Dark Elves" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="3" battleScribeVersion="2.03" type="catalogue" authorContact="Giloushaker#2496">
   <sharedProfiles>
     <profile name="Dark Elf Dreadlord" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="ee4f-5f57-cc9d-7dbb">
       <characteristics>
@@ -896,7 +896,7 @@ Note that this modifier is not cumulative.</characteristic>
         <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
       </characteristics>
     </profile>
-    <profile name="Serrated maw" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="342c-7845-81e4-4cec">
+    <profile name="Serrated Maw" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="342c-7845-81e4-4cec" page="177" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="R" typeId="2360-c777-5e07-ed58">Combat</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">S</characteristic>
@@ -907,7 +907,7 @@ Note that this modifier is not cumulative.</characteristic>
     </profile>
     <profile name="Manbane" typeId="2fa-e08a-dbff-ca1" typeName="Forbidden Poison" hidden="false" id="b38a-b0bf-a43-b92b">
       <characteristics>
-        <characteristic name="Description" typeId="f97f-b811-3dd8-c53b">When this character makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness.</characteristic>
+        <characteristic name="Description" typeId="f97f-b811-3dd8-c53b">When this character makes a roll To Wound, a roll of 4+ is always a success, regardless of the target’s Toughness.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dark Venom" typeId="2fa-e08a-dbff-ca1" typeName="Forbidden Poison" hidden="false" id="dcbf-e20f-8b45-13e5">
@@ -917,7 +917,7 @@ Note that this modifier is not cumulative.</characteristic>
     </profile>
     <profile name="Black Lotus" typeId="2fa-e08a-dbff-ca1" typeName="Forbidden Poison" hidden="false" id="850b-b31b-63f1-51d1">
       <characteristics>
-        <characteristic name="Description" typeId="f97f-b811-3dd8-c53b">For each unsaved Wound inflicted upon them by this character, enemy characters suffer a -1 modifier to their Leadership characteristic for the remainder of the game</characteristic>
+        <characteristic name="Description" typeId="f97f-b811-3dd8-c53b">For each unsaved Wound inflicted upon them by this character, enemy characters suffer a -1 modifier to their Leadership characteristic for the remainder of the game</characteristic>
       </characteristics>
     </profile>
     <profile name="Cry of War" typeId="d6d5-bc1d-f0d9-ec55" typeName="Gifts Of Khaine" hidden="false" id="a016-7f5e-e8a2-e2a4">
@@ -1071,13 +1071,7 @@ Note that this modifier is not cumulative.</characteristic>
       </characteristics>
       <comment>Kharibdyss/Beastmaster Handlers</comment>
     </profile>
-    <profile name="Unable to read profile from 
-                                  R     S     Special Rules AP
-Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,
-                                                            -1
-                                              Requires Two Hands
-Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in
-which it charged." typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="8bd5c110-1d06685a">
+    <profile name="Unable to read profile from                                    R     S     Special Rules AP Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,                                                             -1                                               Requires Two Hands Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in which it charged." typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="8bd5c110-1d06685a">
       <characteristics>
         <characteristic name="R" typeId="2360-c777-5e07-ed58"/>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7"/>
@@ -1151,21 +1145,9 @@ their repeater crossbow.</characteristic>
         <infoLink targetId="a990-96ae-131f-1176" id="a1ee-94eb-7c95-7de8" type="profile" name="Witchbrew" hidden="false"/>
       </infoLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Unable to read profile from 
-                                  R     S     Special Rules AP
-Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,
-                                                            -1
-                                              Requires Two Hands
-Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in
-which it charged." hidden="false" id="712d0a4f-9ce5f4dd">
+    <selectionEntry type="upgrade" import="true" name="Unable to read profile from                                    R     S     Special Rules AP Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,                                                             -1                                               Requires Two Hands Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in which it charged." hidden="false" id="712d0a4f-9ce5f4dd">
       <infoLinks>
-        <infoLink name="Unable to read profile from 
-                                  R     S     Special Rules AP
-Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,
-                                                            -1
-                                              Requires Two Hands
-Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in
-which it charged." hidden="false" id="b005d805-6713cefb" type="profile" targetId="8bd5c110-1d06685a"/>
+        <infoLink name="Unable to read profile from                                    R     S     Special Rules AP Dread halberd                   Combat S+1    Armour Bane (1), Fight in Extra Rank,                                                             -1                                               Requires Two Hands Notes: A model wielding a dread halberd cannot make a supporting attack during a turn in which it charged." hidden="false" id="b005d805-6713cefb" type="profile" targetId="8bd5c110-1d06685a"/>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Serrated maw" hidden="false" id="4ccd433-1aaa53e1">

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -165,7 +165,7 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule has a 5+ Ward save against any wounds suffered that were caused by an attack that has the Flaming Attacks special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="24" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Drakegun" hidden="false" id="b22b-104e-4b47-bcba" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="24" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 18&quot;	S: 5	AP: -1	Special Rules: Armour Bane (2), Dwarf Crafted, Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
@@ -193,22 +193,22 @@ A Runesmith counts as a Level 1 Wizard</characteristic>
         <characteristic name="Description" typeId="e1f9-c2b6-81a4-2d6">Any enemy unit that charges the front arc of a unit carrying a standard inscribed with the Rune of Confusion makes a disordered charge.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Great Hammer" hidden="false" id="180a-c8b3-6ed1-5921" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Great Hammer" hidden="false" id="180a-c8b3-6ed1-5921" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2 AP-1 Armour Bane(2), Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Brace of Drakefire Pistols" hidden="false" id="76d4-c34d-d3dd-bedd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Brace of Drakefire Pistols" hidden="false" id="76d4-c34d-d3dd-bedd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">???</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blasting Charges" hidden="false" id="c4cd-20ce-ab7a-199e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="26" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Blasting Charges" hidden="false" id="c4cd-20ce-ab7a-199e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="26" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 6&quot;	S: 3	AP: -1	Special Rules: Armour Bane (1), Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Drill" hidden="false" id="1394-5f7d-15ff-3370" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="26" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Steam Drill" hidden="false" id="1394-5f7d-15ff-3370" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="26" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+3	AP: -3	
 Notes: A unit of Miners held in reserve that includes a Prospector equipped with a steam drill may re-roll the D6 when rolling to determine if they arrive on the battlefield.	Special Rules: Furious Charge, Requires Two Hands, Strike Last</characteristic>
@@ -232,17 +232,17 @@ Notes: A unit of Miners held in reserve that includes a Prospector equipped with
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Gun" hidden="false" id="161c-d7a-993b-854e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Steam Gun" hidden="false" id="161c-d7a-993b-854e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-1 Breath Weapon</characteristic>
       </characteristics>
     </profile>
-    <profile name="Brimstone Gun" hidden="false" id="aa5b-18d2-c8c0-e4d6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="28" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Brimstone Gun" hidden="false" id="aa5b-18d2-c8c0-e4d6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 18&quot;	S: 5	AP: -2	Special Rules: Dwarf Crafted, Flaming Attacks, Multiple Shots (D3+1), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="28" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Clattergun" hidden="false" id="e2de-d72a-fe52-92e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="28" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 4	AP: -1	Special Rules: Armour Bane (1), Dwarf Crafted, Move &amp; Shoot, Multiple Shots (D6), Quick Shot</characteristic>
       </characteristics>
@@ -494,7 +494,7 @@ Bombing Run Table:
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with Shieldbearers consists of not one, but four models – the character and three loyal retainers – occupying a single base and acting together as a single entity. To represent this, a model with Shieldbearers has a split profile and follows the ‘Split Profile (Cavalry)’ rule. In all other respects, this model is heavy infantry.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Oathstone" hidden="false" id="c605-51c5-a70e-ff3d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Oathstone" hidden="false" id="c605-51c5-a70e-ff3d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Challenges issued by a character with an Oathstone cannot be refused. In addition, a character with an Oathstone and any unit they have joined automatically passes any Panic tests they are required to make, but cannot chose to Flee as a charge reaction.</characteristic>
       </characteristics>
@@ -588,13 +588,13 @@ Hex, 8+/11+, 24&quot; : If the Bound spell is cast with a casting result of 8 or
         <characteristic name="Description" typeId="8e20-307f-c900-61b3">When making a roll to Wound with a weapon inscribed with the Master Rune of Skalf Blackhammer, a roll of 2+ is always a success, regardless of the target&apos;s Toughness.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cinderblast Bombs" hidden="false" id="edb7-2817-a45e-9e05" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="25" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Cinderblast Bombs" hidden="false" id="edb7-2817-a45e-9e05" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="25" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 8&quot;	S: 5	AP: -1	
 Notes: A unit hit by a cinderblast bomb suffers D6+1 hits (rather than the usual one).	Special Rules: Flaming Attacks, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Trollhammer Torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="191c-940d-96bf-e9e3" page="25" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Trollhammer Torpedo" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="191c-940d-96bf-e9e3" page="25" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 8	AP: -3	Special Rules: Dwarf Crafted, Flaming Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>

--- a/Giant Library.cat
+++ b/Giant Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="4013-4240-7515-27e0" name="Giant Library" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="47" revision="2" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="4013-4240-7515-27e0" name="Giant Library" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="47" revision="2" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Giant&apos;s Club" hidden="false" id="742-e3dd-26f9-778f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>

--- a/Giant Library.cat
+++ b/Giant Library.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="4013-4240-7515-27e0" name="Giant Library" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="47" revision="1" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="4013-4240-7515-27e0" name="Giant Library" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="47" revision="2" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedProfiles>
-    <profile name="Giant&apos;s Club" hidden="false" id="742-e3dd-26f9-778f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Giant&apos;s Club" hidden="false" id="742-e3dd-26f9-778f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9"/>
       </characteristics>

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="56fb-835b-a377-6639" name="High Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="40" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="56fb-835b-a377-6639" name="High Elf Realms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="41" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Sons of Caledor" hidden="false" id="2f86-a9f-38aa-d39a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
@@ -42,7 +42,7 @@
 Note that this special rule only applies to a single, non-magical hand weapon and does not apply to a model’s mount (should it have one). If the model is using two hand weapons or any other sort of weapon, this special rule ceases to apply.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Chracian Great Blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Chracian Great Blade" hidden="false" id="66ca-f1a3-7cc3-723d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+2	AP: -3	Special Rules: Requires Two Hands, Strike Last</characteristic>
       </characteristics>
@@ -62,18 +62,18 @@ Note that this special rule only applies to a single, non-magical hand weapon an
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Whilst in base contact with this model, enemy models become subject to the Strike Last special rule.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Bow of Avelorn" hidden="false" id="e42c-4a2f-b084-91c0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Bow of Avelorn" hidden="false" id="e42c-4a2f-b084-91c0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 30&quot;	S: S	AP: -	Special Rules: Armour Bane (1), Magical Attacks, Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ceremonial Halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Ceremonial Halberd" hidden="false" id="2708-e296-37ed-385b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+1	AP: -1	
 Notes: A model wielding a ceremonial halberd cannot make a supporting attack during a turn in which it charged.	Special Rules: Armour Bane (1), Fight in Extra Rank, Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dragon fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="174" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Dragon fire" hidden="false" id="f34b-f68e-23c7-145f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="174" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 4	AP: -1	Special Rules: Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
@@ -104,12 +104,12 @@ Notes: A model wielding a ceremonial halberd cannot make a supporting attack dur
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Handmaiden&apos;s Spear" hidden="false" id="cb8b-78-2f65-59c3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Handmaiden&apos;s Spear" hidden="false" id="cb8b-78-2f65-59c3" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S5 AP-1 During a turn in which it was charged, a model wielding a Handmaiden&apos;s spear gains a +1 modifier to its Initiative against the charging unit(s).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Eagle-eye Bolt Thrower" hidden="false" id="6ff2-57b7-2d12-a850" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="172" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Eagle-eye Bolt Thrower" hidden="false" id="6ff2-57b7-2d12-a850" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="172" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 5	AP: -3	Special Rules: Cumbersome, Multiple Wounds (D3)</characteristic>
       </characteristics>
@@ -119,7 +119,7 @@ Notes: A model wielding a ceremonial halberd cannot make a supporting attack dur
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Any bow (longbow, shortbow, warbow or Bow of Avelorn) carried by a model with this special rule has the Armour Bane (1) special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="187" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Sword of Hoeth" hidden="false" id="e54f-fb20-3641-aa1b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="187" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+2	AP: -2	Special Rules: Magical Attacks, Requires Two Hands</characteristic>
       </characteristics>

--- a/Lizardmen.cat
+++ b/Lizardmen.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ab16-38c2-b85a-9197" name="Lizardmen" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Giloushaker#2496">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="ab16-38c2-b85a-9197" name="Lizardmen" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="2" battleScribeVersion="2.03" type="catalogue" authorContact="Giloushaker#2496">
   <sharedProfiles>
     <profile name="Slann Mage-Priest" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="e2b9-fc0e-f107-4ae">
       <characteristics>

--- a/Ogre Kingdoms.cat
+++ b/Ogre Kingdoms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Giloushaker#2496">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="3" battleScribeVersion="2.03" type="catalogue" authorContact="Giloushaker#2496">
   <sharedProfiles>
     <profile name="Tyrant" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="f58e-2d63-3721-5926">
       <characteristics>
@@ -713,11 +713,11 @@ For this attack, the Giant does not use its club. Instead, the target unit suffe
         <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
       </characteristics>
     </profile>
-    <profile name="Flaming breath" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="49f4-a3bb-871d-64df">
+    <profile name="Flaming Breath" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="49f4-a3bb-871d-64df" page="75" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="R" typeId="2360-c777-5e07-ed58">N/A</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">4</characteristic>
-        <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-1</characteristic>
+        <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-</characteristic>
         <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Breath Weapon, Flaming Attacks</characteristic>
         <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
       </characteristics>
@@ -821,35 +821,28 @@ For this attack, the Giant does not use its club. Instead, the target unit suffe
         <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
       </characteristics>
     </profile>
-    <profile name="*Giant Attacks" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="e433-20e5-52c4-8f15">
+    <profile name="*Giant Attacks" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="e433-20e5-52c4-8f15" page="108" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Giants do not attack in the same way as other creatures. They are far too large and fractious to
-take orders and much too scatter-brained to have any sort of coherent plan.
-Instead of attacking normally during the Combat phase or making a Pick Up And… attack,
-a Giant may choose to make a ‘Giant Attack’. To make a Giant Attack, nominate an enemy
-unit that the Giant is engaged in combat with to be the target of the attack and roll on the
-Giant Attacks table below to determine what the Giant does:</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Instead of attacking normally during the Combat phase or making a Pick Up And… attack, a Giant may choose to make a ‘Giant Attack’. To make a Giant Attack, nominate an enemy unit that the Giant is engaged in combat with to be the target of the attack and roll on the Giant Attacks table below to determine what the Giant does:
+Giant Attacks Table:
+● D6:	Result
+● 1:	’Eadbutt:  The Giant singles out a lone enemy and ’eadbutts them. Nominate a single model in the fighting rank of an enemy unit the Giant is engaged with to be the target of this attack. That model is hit and suffers D3+1 wounds with no armour or Regeneration saves permitted (Ward saves can be attempted as normal).
+● 2:	Belly Flop:  The Giant crashes down bodily upon the enemy. Place a small (3&quot;) blast template so that its central hole is directly over the centre of the target unit. Any model (friend or foe, but not including this model) whose base lies underneath the template risks being hit and suffering a single hit, using the Strength characteristic of this model, with an AP of -2.
+● 3-4:	Mighty Swing:  The Giant swings its club through the enemy ranks. For this attack, the Giant is subject to the Random Attacks special rule and has an Attacks characteristic of D6+1, and the Giant’s club has a Strength characteristic of S+1 and an AP of -2.
+● 5:	Thump With Club:  The Giant grasps its club two-handed and cracks its enemy on the head. Nominate a single model in the fighting rank of an enemy unit the Giant is engaged with to be the target of this attack. For this attack, the Giant’s club has a Strength characteristic of S+4, an AP of -4 and the Multiple Wounds (D6) special rule.
+● 6:	Jump Up &amp; Down:  The Giant jumps around, kicking and flattening the enemy. For this attack, the Giant does not use its club. Instead, the target unit suffers D6+1 hits, each using the Strength characteristic of this model, with no armour save permitted (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="*Pick Up And…" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="ee32-71e0-ce47-435f">
+    <profile name="*Pick Up And…" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="ee32-71e0-ce47-435f" page="109" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Instead of attacking normally during the Combat phase or making a Giant Attack, a Giant
-that is engaged in combat with one or more units whose troop type is ‘regular infantry’ or
-‘heavy infantry’ may choose to make a ‘Pick Up And…’ attack. To make a Pick Up And…
-attack, nominate an enemy unit of regular or heavy infantry that the Giant is engaged in
-combat with. The unit must immediately make an Initiative test:
-• If this test is failed, a victim is picked up by the Giant. What happens next does not
-bear thinking about but, whatever it is, a single model belonging to the target unit is
-immediately removed from play as a casualty.
-• If this test is passed, the warriors manage to duck and dodge away from the Giant’s
-grasping hands. No one is picked up and the attack has no effect.
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Instead of attacking normally during the Combat phase or making a Giant Attack, a Giant that is engaged in combat with one or more units whose troop type is ‘regular infantry’ or ‘heavy infantry’ may choose to make a ‘Pick Up And…’ attack. To make a Pick Up And… attack, nominate an enemy unit of regular or heavy infantry that the Giant is engaged in combat with. The unit must immediately make an Initiative test:
+•	If this test is failed, a victim is picked up by the Giant. What happens next does not bear thinking about but, whatever it is, a single model belonging to the target unit is immediately removed from play as a casualty.
+•	If this test is passed, the warriors manage to duck and dodge away from the Giant’s grasping hands. No one is picked up and the attack has no effect.
 Next, roll a D6:
-• On a roll of 1-3, the Giant forgets what it is doing and makes no further attacks.
-• On a roll of 4+, the Giant attempts to pick up another enemy. The target unit must
-make another Initiative test.
-This continues until the Giant forgets what it is doing and stops making attacks, or until
-the target unit is destroyed.
-Enemy models removed from p</characteristic>
+•	On a roll of 1-3, the Giant forgets what it is doing and makes no further attacks.
+•	On a roll of 4+, the Giant attempts to pick up another enemy. The target unit must make another Initiative test.
+This continues until the Giant forgets what it is doing and stops making attacks, or until the target unit is destroyed.
+Enemy models removed from play are considered to have been removed from the fighting rank of the enemy unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Scraplauncher catapult" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="2228-5b2-4acc-968f">
@@ -927,7 +920,7 @@ Enemy models removed from p</characteristic>
         <characteristic name="R" typeId="2360-c777-5e07-ed58">24&quot;</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">4</characteristic>
         <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-1</characteristic>
-        <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Armour Bane (1), Multiple Shots (2), Quick Shot</characteristic>
+        <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Armour Bane (1), Multiple Shots (2), Quick Shot</characteristic>
         <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71"/>
       </characteristics>
     </profile>
@@ -937,9 +930,9 @@ Enemy models removed from p</characteristic>
         <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">S</characteristic>
         <characteristic name="AP" typeId="9429-ffe7-2ce5-e9a5">-</characteristic>
         <characteristic name="Special Rules" typeId="5f83-3633-336b-93b4">Extra Attacks (1), Requires Two Hands</characteristic>
-        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">An Ironfist is an additional hand weapon (as described on page 213 of the Warhammer:the Old World rulebook. 
-In addition, a model equipped with an Ironfist improves its armour value by 1. 
-An Ironfist cannot be used alongside a magic weapon to gain an extra attack, or to improve the wielder’s armour value.</characteristic>
+        <characteristic name="Notes" typeId="772a-a7ff-f6b3-df71">An Ironfist is an additional hand weapon (as described on page 213 of the Warhammer:the Old World rulebook. 
+In addition, a model equipped with an Ironfist improves its armour value by 1. 
+An Ironfist cannot be used alongside a magic weapon to gain an extra attack, or to improve the wielder’s armour value.</characteristic>
       </characteristics>
     </profile>
     <profile name="Leadbelcher" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="421a-ebbd-5cc-f9e0">
@@ -1138,7 +1131,7 @@ An Ironfist cannot be used alongside a magic weapon to gain an extra attack, or 
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Giant’s club" hidden="false" id="ce35-f2b0-61a8-698a">
       <profiles>
-        <profile name="Giant’s club" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="65d2-cce4-628a-bf52">
+        <profile name="Giant’S Club" typeId="a378-c633-912d-11ce" typeName="Weapon" hidden="false" id="65d2-cce4-628a-bf52" page="109" publicationId="7c89-736c-3139-24a0">
           <characteristics>
             <characteristic name="R" typeId="2360-c777-5e07-ed58">Combat</characteristic>
             <characteristic name="S" typeId="ac19-f99c-72e9-a1a7">*</characteristic>

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -5011,7 +5011,7 @@ Note that this modifier is not cumulative.</characteristic>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Nasty Skulkers are not placed on the battlefield at the start of the game. Instead, make a note of which Goblin Mobs include Nasty Skulkers, and of how many they include. These units are referred to as ‘concealing’ units. At the start of its first round of combat, during Step 1.1 of the Choose Combat &amp; Fight sub-phase, a concealing unit must reveal its Nasty Skulkers – they cannot be revealed at any other time. Position each revealed Nasty Skulker as you would a character that has joined the unit. Once placed, Nasty Skulkers cannot leave their concealing unit. If a concealing unit is destroyed or flees the battlefield before its Nasty Skulkers are revealed, they are removed as casualties.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Troll Vomit" hidden="false" id="cdde-5994-8941-787f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Troll Vomit" hidden="false" id="cdde-5994-8941-787f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S 3 AP2</characteristic>
       </characteristics>
@@ -5529,7 +5529,7 @@ Note that, for the purposes of this rule, a unit of Orcs is considered to be any
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Combat S S AP1 Armourbane (1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Giant Club" hidden="false" id="600e-c97a-3c61-9f5b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Giant Club" hidden="false" id="600e-c97a-3c61-9f5b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">A Giant&apos;s club may have different characteristics and special rules depending upon what they do with it, as described in the [Giant Attacks] special rule.</characteristic>
       </characteristics>
@@ -5624,12 +5624,12 @@ Note that, for the purposes of this rule, a unit of Orcs is considered to be any
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">3</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spidersilk Lobber" hidden="false" id="1feb-b4ec-6cfc-8f7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Spidersilk Lobber" hidden="false" id="1feb-b4ec-6cfc-8f7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2 [12-48&quot; S2(4) AP-(-1) [Bombardment], [Cumbersome] This weapon shoots like a stone thrower, using the [Bombardment] special rule and a 5&quot; blast template. If a &apos;Misfire&apos; is rolled on the Artillery dice, this model loses a single Wound (instead of rolling on a Misfire table).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Venom surge" hidden="false" id="d4a3-bdc8-bdad-bb9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="36" publicationId="7c89-736c-3139-24a0">
+    <profile name="Venom surge" hidden="false" id="d4a3-bdc8-bdad-bb9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="36" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -2	
 Notes: In combat, this model may choose to make one of its attacks each turn with this weapon.	Special Rules: Multiple Wounds (D6), Poisoned Attacks, Strike First</characteristic>
@@ -5659,7 +5659,7 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">10</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fanatic Ball &amp; Chain" hidden="false" id="1f92-933c-dfaa-bd0a" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Fanatic Ball &amp; Chain" hidden="false" id="1f92-933c-dfaa-bd0a" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Any unit (friend ofr foe) that is moved through by a moving Fanatic, or that moves through a Fanatic, suffers D6 Strength 5 hits, each with an AP of -3.</characteristic>
       </characteristics>
@@ -5695,7 +5695,7 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Should a Squig Herd ever Break and flee from combat, the Cave Squigs will go wild. If the Squig Herd contains five or more Cave Squigs, every unit (friend or foe) within 2D6&quot; of it suffers D3 Strength 5 hits, each with an AP of -1. For every additional five Cave Squigs the Squig Herd contains, apply a +1 modifier to the D3. Once these hits have been resolved, treat the unit as having been completely destroyed in combat and remove it from play.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Huge gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="32" publicationId="7c89-736c-3139-24a0">
+    <profile name="Huge gob" hidden="false" id="82e4-fca1-31c7-48f9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="32" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	Special Rules: Armour Bane (1)</characteristic>
       </characteristics>
@@ -5718,7 +5718,7 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Mangler Squigs treat all difficult terrain as dangerous terrain.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Colossal Gang-Filled Gob" hidden="false" id="fc81-c5b4-c632-2a80" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Colossal Gang-Filled Gob" hidden="false" id="fc81-c5b4-c632-2a80" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Ap-2 [Killing Blow]</characteristic>
       </characteristics>
@@ -5728,7 +5728,7 @@ Death of a Fanatic: A Fanatic model cannot be charged, targeted or attacked in a
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by this model have an Armour Piercing characteristic of -3.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Venomous Tail" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="c761-4dde-b2c8-b6fe">
+    <profile name="Venomous Tail" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="c761-4dde-b2c8-b6fe">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Combat S - [Poisoned Attacks], [Strike First]</characteristic>
       </characteristics>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="20b-6412-2ac1-d146" name="Skaven" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="Giloushaker#2496">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="20b-6412-2ac1-d146" name="Skaven" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="2" battleScribeVersion="2.03" type="catalogue" authorContact="Giloushaker#2496">
   <sharedProfiles>
     <profile name="Skaven Warlord" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="a4f2-1637-63e4-25df">
       <characteristics>

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -121,7 +121,7 @@ Note that a unit with the Unbreakable special rule cannot normally be joined by 
 •	A 5+ Ward save against any wounds suffered that were caused by a non-magical enemy attack with a Strength 5 or higher.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Helblaster Volley Gun" hidden="false" id="e8cc-62ef-8348-4584" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="72" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Helblaster Volley Gun" hidden="false" id="e8cc-62ef-8348-4584" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="72" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 5	AP: -1	
 Notes: This weapon uses the Black Powder Misfire table.	Special Rules: Armour Bane (2), Cumbersome, Helblaster, Move or Shoot</characteristic>
@@ -138,7 +138,7 @@ Notes: This weapon uses the Black Powder Misfire table.	Special Rules: Armour Ba
 3- Damage: Any model whose base lies underneath a template risks being hit by this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam cannon" hidden="false" id="b3c6-a5b6-2c6d-73a7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="69" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Steam cannon" hidden="false" id="b3c6-a5b6-2c6d-73a7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="69" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 8	AP: -2	
 Notes: This weapon shoots like a cannon, using the ‘Cannon Fire’ special rule. If a ‘Misfire’ is rolled on the Artillery dice during step 2, this model loses a single Wound (instead of rolling on a Misfire table).	Special Rules: Armour Bane (2), Cannon Fire, Cumbersome, Multiple Wounds (D3)</characteristic>
@@ -172,7 +172,7 @@ In addition, and unlike other chariots, this model treats low linear obstacles a
 However, if a natural 1 is rolled on both of the dice, the pressure is too great to be release safely. The Steam Tank loses a single Wound and halts immediately. It cannot move ahain for the reminder of this turn.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Steam Gun" hidden="false" id="145e-aad1-ec61-5b6f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Steam Gun" hidden="false" id="145e-aad1-ec61-5b6f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon. No armour saves is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal)</characteristic>
       </characteristics>
@@ -203,7 +203,7 @@ After determining the number of shots, roll To hit for each as normal, using the
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless this unit is fleeing, friendly units within 6&quot; of it automatically pass any Fear tests they are required to make and can re-roll any failed Panic tests.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Helstorm Rocket Battery" hidden="false" id="4f4b-796c-5654-e56d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="73" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Helstorm Rocket Battery" hidden="false" id="4f4b-796c-5654-e56d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="73" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12-48&quot;	S: 3	AP: -1	
 Notes: This weapon uses a number of 3&quot; blast templates and the Black Powder Misfire table.	Special Rules: Cumbersome, Helstorm, Move or Shoot</characteristic>
@@ -599,19 +599,19 @@ Notes: This weapon uses a number of 3&quot; blast templates and the Black Powder
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Hochland long rifle" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="ec0a-ce53-127c-7c0d" page="77" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Hochland long rifle" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="ec0a-ce53-127c-7c0d" page="77" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 36&quot;	S: 4	AP: -1	
 Notes: A model armed with a Hochland long rifle can target a specific model within its target unit, such as a champion or a character.	Special Rules: Armour Bane (1), Cumbersome, Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Grenade launching blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="b8f7-c4e5-2793-bc18" page="77" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Grenade launching blunderbuss" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="b8f7-c4e5-2793-bc18" page="77" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot;	S: 4	AP: -2	
 Notes: If the roll To Hit is successful, a grenade launching blunderbuss causes D3+1 hits to the target enemy unit, rather than the usual one hit.	Special Rules: Cumbersome, Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Pigeon Bombs" hidden="false" id="d71-dbcc-b41f-1429" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Pigeon Bombs" hidden="false" id="d71-dbcc-b41f-1429" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Instead of shooting normally during the Shooting phase, a model equipped with pigeon bombs may release one. Choose an enemy unit that is within 24&quot; of the model and roll a D6 on the Pigeon Bomb table below:
 

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="29" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="be27-8084-f552-1f4" name="Tomb Kings of Khemri" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="33" revision="30" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Dry as Dust" hidden="false" id="ae9b-6cef-787a-da54" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="153" publicationId="7c89-736c-3139-24a0">
       <characteristics>
@@ -108,59 +108,59 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the Fly special rule and choose to move by flying). In addition, all Undead models have the following universal special rules:</characteristic>
       </characteristics>
     </profile>
-    <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="135" publicationId="7c89-736c-3139-24a0">
+    <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="135" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 30&quot;	S: 6	AP: -1	Special Rules: Armour Bane (2), Multiple Wounds (2), Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Writhing tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="7c89-736c-3139-24a0">
+    <profile name="Writhing tail" hidden="false" id="44c1-e35a-914f-4910" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="140" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	
 Notes: In combat, a Sepulchral Stalker may make an additional D3 attacks each turn, each of which must be made with this weapon (roll separately for each model in the unit).	Special Rules: Extra Attacks (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ritual blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="60042717016" publicationId="afac-86a8-e0f-2eef">
+    <profile name="Ritual blade" hidden="false" id="d60d-f2aa-d051-1598" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="60042717016" publicationId="afac-86a8-e0f-2eef">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+2	AP: -3	Special Rules: Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
-    <profile name="Petryfing Gaze" hidden="false" id="d8-cf66-7b84-5ede" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Petryfing Gaze" hidden="false" id="d8-cf66-7b84-5ede" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">18&quot; S2 Magical Attacks, Multiple Wounds (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Breath of Dessication" hidden="false" id="8a97-d97-f22f-163b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Breath of Dessication" hidden="false" id="8a97-d97-f22f-163b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 Breath Weapon, Magical Attacks, Multiple Wounds (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Envenomed sting" hidden="false" id="fc42-a5d4-da36-c3ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="146" publicationId="7c89-736c-3139-24a0">
+    <profile name="Envenomed sting" hidden="false" id="fc42-a5d4-da36-c3ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -	
 Notes: In combat, this model may choose to make one of its attacks each turn with this weapon.	Special Rules: Poisoned Attacks, Strike First</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fiery roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="143" publicationId="7c89-736c-3139-24a0">
+    <profile name="Fiery roar" hidden="false" id="f5ac-a5f3-44b9-38ca" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="143" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 4	AP: -1	Special Rules: Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>
     </profile>
-    <profile name="Decapitating claws" hidden="false" id="323c-206b-c9fd-7c8d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="144" publicationId="7c89-736c-3139-24a0">
+    <profile name="Decapitating claws" hidden="false" id="323c-206b-c9fd-7c8d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="144" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -2	Special Rules: Killing Blow, Monster Slayer</characteristic>
       </characteristics>
     </profile>
-    <profile name="Paired Great Khopeshes" hidden="false" id="7b2c-46ee-f170-7afe" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Paired Great Khopeshes" hidden="false" id="7b2c-46ee-f170-7afe" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2 Killing Blow, Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cleaving blades" hidden="false" id="96c2-db5e-991a-9ba0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="146" publicationId="7c89-736c-3139-24a0">
+    <profile name="Cleaving blades" hidden="false" id="96c2-db5e-991a-9ba0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="146" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	Special Rules: Killing Blow</characteristic>
       </characteristics>
     </profile>
-    <profile name="Decapitating Strike" hidden="false" id="8232-8b83-ab9f-3849" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Decapitating Strike" hidden="false" id="8232-8b83-ab9f-3849" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+5 AP-4 [Killing Blow], [Monster Slayer], [Strike Last]</characteristic>
       </characteristics>
@@ -2969,7 +2969,7 @@ Note that any unsaved wounds caused by the Stomp Attacks (D3) special rule do no
                 <cost name="pts" typeId="points" value="2"/>
               </costs>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e88b-b43f-834-3f57"/>              
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e88b-b43f-834-3f57"/>
                 <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6902-8906-38db-fd3d"/>
               </constraints>
             </selectionEntry>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -48,11 +48,11 @@ Note that this special rule is not cumulative. In other words, using it more tha
 Note, however, that this bonus does not apply to any Bound spells cast by a Casket of Souls.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Banner of the King" hidden="false" id="d88f-102f-fef9-dab2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
+    <profile name="Banner Of The King" hidden="false" id="d88f-102f-fef9-dab2" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Royal Herald that has been upgraded to be your Battle Standard Bearer replaces the “Hold Your Ground” rule given in the Warhammer: the Old World rulebook with the version given below:
 “Hold Your Ground”: Friendly units within the Battle Standard Bearer’s Command range may re-roll any failed Leadership test. In addition, friendly units within the Battle Standard Bearer’s Command range reduce the number of Wounds lost due to the Unstable special rule by D3.
-Note that this is not cumulative with the Indomitable special rule (see page 153). If a unit is affected by both, use the highest value.</characteristic>
+Note that this is not cumulative with the Indomitable (X) special rule (see page 153). If a unit is affected by both, use the highest value.</characteristic>
       </characteristics>
     </profile>
     <profile name="Sworn Protector" hidden="false" id="26cd-4c1b-a55b-93a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="127" publicationId="7c89-736c-3139-24a0">
@@ -105,7 +105,7 @@ Note that Ambushers arrive automatically at the start of round five as usual.</c
     </profile>
     <profile name="Nehekharan Undead" hidden="false" id="cc25-1643-8beb-8c64" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the Fly special rule and choose to move by flying). In addition, all Undead models have the following universal special rules:</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule are ‘Undead’. Undead models cannot march (unless they have the Fly (X) special rule and choose to move by flying). In addition, all Undead models have the following universal special rules:</characteristic>
       </characteristics>
     </profile>
     <profile name="Greatbow" hidden="false" id="81ae-bc93-5af2-ad67" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="135" publicationId="7c89-736c-3139-24a0">
@@ -178,7 +178,7 @@ Notes: In combat, this model may choose to make one of its attacks each turn wit
     <profile name="The Hierophant" hidden="false" id="c9c5-7aab-8e2e-2646" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="129" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Your army must include at least one Liche Priest to be its Hierophant. If your army includes several Liche Priests, the Hierophant will be the one with the highest Level of Wizardry. If two or more models have the highest Wizard Level, you may choose which one is the Hierophant when writing your muster list. You must tell your opponent which model is your Hierophant before deploying your army.
-Should the Hierophant be slain, the magical animus of the army starts to dissipate. As soon as the Hierophant is removed from play as a casualty, all friendly units with the Nehekharan Undead special rule lose the Regeneration special rule.
+Should the Hierophant be slain, the magical animus of the army starts to dissipate. As soon as the Hierophant is removed from play as a casualty, all friendly units with the Nehekharan Undead special rule lose the Regeneration (X) special rule.
 In addition, at the end of the phase in which your Hierophant was removed from play as a casualty, and during each of your Start of Turn sub-phases for the remainder of the game, all friendly units with the Nehekharan Undead special rule that are currently on the battlefield must make a Leadership test. If this test is failed, the unit loses a number of Wounds equal to the amount by which it failed the test.
 For example: Your army’s Hierophant is destroyed during your opponent’s Shooting phase. At the end of that phase a unit of Skeleton Warriors (Ld 5) makes a Leadership test and rolls a 7 (failing the test by 2). That unit immediately loses two Wounds. During your next Start of Turn sub-phase, the same unit makes another Leadership test, this time rolling a 6, resulting in the loss of one Wound.</characteristic>
       </characteristics>

--- a/Vampire Counts.cat
+++ b/Vampire Counts.cat
@@ -769,12 +769,12 @@ The target must make a Leadership test with a -2 modifier to its Leadership char
 Note that a Wailing Dirge attack can target an enemy character, regardless of the usual rules for targeting Lone characters.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Resurrecting The Fallen" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c1d3-29e3-b7cd-c9f7">
+    <profile name="Resurrecting The Fallen" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c1d3-29e3-b7cd-c9f7" page="154" publicationId="7c89-736c-3139-24a0">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Wounds recovered in this way follow a strict order: • First, any characters that have joined the unit are healed. A character that has been reduced to zero Wounds and removed from play cannot be resurrected.
-• Second, models with more than one Wound on their profile are healed.
-• Next, the unit champion is resurrected, displacing rank-and-file models as required, followed by the standard bearer and musician.
-• Finally, rank-and-file models are resurrected.
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">•	First, any characters that have joined the unit are healed. A character that has been reduced to zero Wounds and removed from play cannot be resurrected.
+•	Second, models with more than one Wound on their profile are healed.
+•	Next, the unit champion is resurrected, displacing rank-and-file models as required, followed by the standard bearer and musician.
+•	Finally, rank-and-file models are resurrected.
 Note that, in the case of multiple Wound models, each model must be fully healed, recovering all of its lost Wounds, before another can be healed or resurrected.
 Note also that at least one model must remain in order for a unit to be healed. In other words, a unit that has been reduced to zero Wounds and removed from play cannot be resurrected.
 Resurrected models are added to the front rank until it reaches the minimum required to claim a Rank Bonus, after which additional models can be added to the front or rear rank. If the unit already has more than one rank, models can only be added to the rear rank. A unit cannot be taken beyond its starting size.</characteristic>
@@ -940,7 +940,7 @@ Note that this special rule is not cumulative. If two or more models in a unit h
     </profile>
     <profile name="Lore Of Undeath" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="790b-ac72-a11e-cdbf">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the ‘Lore of Undeath’ special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead either the signature spell of their chosen Lore of Magic, or one of the spells listed below:
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Wizard with the ‘Lore of Undeath’ special rule may discard one of their randomly generated spells as normal. When they do so, they may select instead either the signature spell of their chosen Lore of Magic, or one of the spells listed below:
 • Vanhal’s Danse Macabre
 • Hellish Vigour
 • Raise Dead</characteristic>
@@ -1038,27 +1038,27 @@ Note that this is not cumulative with the Indomitable (X) special rule (see page
     </profile>
     <profile name="Lord of the Night" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="6ce2-e337-833e-9ece" page="23" publicationId="1c5e-3047-5732-f4">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this Vampire may attempt to resurrect fallen creatures of the night by making a Leadership test (using their own Leadership). If this test is passed, a single friendly unit of Fell Bats, Bat Swarms or Dire Wolves that is within 12&quot; of this model recovers D6 lost Wounds.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, this Vampire may attempt to resurrect fallen creatures of the night by making a Leadership test (using their own Leadership). If this test is passed, a single friendly unit of Fell Bats, Bat Swarms or Dire Wolves that is within 12&quot; of this model recovers D6 lost Wounds.</characteristic>
       </characteristics>
     </profile>
     <profile name="Beguile" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="5fb6-176c-e1fb-dc04" page="23" publicationId="1c5e-3047-5732-f4">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy units must make a Leadership test before making any rolls To Hit against this Vampire during the Combat phase. If this test is failed, only rolls of a natural 6 will hit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy units must make a Leadership test before making any rolls To Hit against this Vampire during the Combat phase. If this test is failed, only rolls of a natural 6 will hit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Flying Horror" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="c153-1324-145f-96dc" page="23" publicationId="1c5e-3047-5732-f4">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models whose troop type is ‘infantry’ only. This Vampire gains the Fly (10) rule, but cannot join a unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models whose troop type is ‘infantry’ only. This Vampire gains the Fly (10) rule, but cannot join a unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dark Acolyte" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="9349-c828-b9e4-8499" page="23" publicationId="1c5e-3047-5732-f4">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This Vampire gains the Invocation of Nehek special rule (as described on page 5). For the purposes of using this special rule, this model counts as a Level 1 Wizard.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This Vampire gains the Invocation of Nehek special rule (as described on page 5). For the purposes of using this special rule, this model counts as a Level 1 Wizard.</characteristic>
       </characteristics>
     </profile>
     <profile name="Master Of The Black Arts" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="41cf-e8df-d66e-24d1" page="23" publicationId="1c5e-3047-5732-f4">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This Vampiric Power may only be taken by a Vampire Count that is a Level 2 Wizard, or by a Vampire Thrall that is a Level 1 Wizard. This Vampire increases their Level of Wizardry by 1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This Vampiric Power may only be taken by a Vampire Count that is a Level 2 Wizard, or by a Vampire Thrall that is a Level 1 Wizard. This Vampire increases their Level of Wizardry by 1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Supernatural Horror" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="14e0-5897-fa40-f73e" page="23" publicationId="1c5e-3047-5732-f4">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -249,7 +249,7 @@
     </profile>
     <profile name="Close Order" hidden="false" id="883e-e1b1-4fe9-5912" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Close Order formation, as described on page 100.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Close Order formation, as described on page 100.</characteristic>
       </characteristics>
       <comment>#noscript</comment>
     </profile>
@@ -296,12 +296,7 @@
     </profile>
     <profile name="Stubborn" hidden="false" id="e351-bbd6-f470-b604" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">The first time this unit is
-          required to make a Break test it may choose not to and will automatically Fall Back in
-          Good Order instead, even if the Unit Strength of the winning side is more than twice that
-          of the losing side. A unit that is not Stubborn does not become Stubborn when joined by a
-          character that is. A Stubborn character cannot use this special rule whilst part of a unit
-          that is not Stubborn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">The first time this unit is required to make a Break test it may choose not to and will automatically Fall Back in Good Order instead, even if the Unit Strength of the winning side is more than twice that of the losing side. A unit that is not Stubborn does not become Stubborn when joined by a character that is. A Stubborn character cannot use this special rule whilst part of a unit that is not Stubborn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Full Plate Armour" hidden="false" id="9a1d-38b0-7d7-7552" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -311,10 +306,7 @@
     </profile>
     <profile name="Shieldwall" hidden="false" id="32f7-8e30-3fe8-b11e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during a turn
-          in which it was charged, a unit with this special rule that is arrayed in a Close Order
-          formation, and that is equipped with and chooses to use shields, may Give Ground rather
-          than Fall Back in Good Order.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per game, during a turn in which it was charged, a unit with this special rule that is arrayed in a Close Order formation, and that is equipped with and chooses to use shields, may Give Ground rather than Fall Back in Good Order.</characteristic>
       </characteristics>
     </profile>
     <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="217" publicationId="768b-3da1-a182-a1d8">
@@ -325,91 +317,56 @@
     </profile>
     <profile name="Veteran" hidden="false" id="4022-c403-b083-ba83" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the
-          models in a unit have this special rule, the unit may re-roll any failed Leadership test.
-          Note that a Break test is not a Leadership test.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the models in a unit have this special rule, the unit may re-roll any failed Leadership test.
+Note that a Break test is not a Leadership test.</characteristic>
       </characteristics>
     </profile>
     <profile name="Move Through Cover" hidden="false" id="e83e-f127-1904-3858" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule do not suffer any modifiers to their Movement characteristic for moving through
-          difficult or dangerous terrain. In addition, a model with this special rule may re-roll
-          any rolls of 1 when making Dangerous Terrain tests.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not suffer any modifiers to their Movement characteristic for moving through difficult or dangerous terrain. In addition, a model with this special rule may re-roll any rolls of 1 when making Dangerous Terrain tests.</characteristic>
       </characteristics>
     </profile>
     <profile name="Open Order" hidden="false" id="5b67-8535-146c-7cea" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models
-          with this special rule may adopt an Open Order formation, as described on page 182.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt an Open Order formation, as described on page 182.</characteristic>
       </characteristics>
     </profile>
     <profile name="Scouts" hidden="false" id="fe5e-8838-7fbd-a7ec" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule
-          may be deployed after all other units from both armies. They can be deployed anywhere on
-          the battlefield that is more than 12&quot; away from an enemy model. If deployed in this
-          way, Scouts cannot declare a charge during their first turn.
-          If both armies contain Scouts, a roll-off should determine which player deploys Scouts
-          first. The players then alternate deploying their scouting units one at a time, starting
-          with the player who won the roll-off.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may be deployed after all other units from both armies. They can be deployed anywhere on the battlefield that is more than 12&quot; away from an enemy model. If deployed in this way, Scouts cannot declare a charge during their first turn.
+If both armies contain Scouts, a roll-off should determine which player deploys Scouts first. The players then alternate deploying their scouting units one at a time, starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
     <profile name="Skirmishers" hidden="false" id="59a5-7eca-ee35-96ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models
-          with this special rule may adopt a Skirmish formation, as described on page 184.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit consisting of models with this special rule may adopt a Skirmish formation, as described on page 184.</characteristic>
       </characteristics>
     </profile>
     <profile name="Detachment" hidden="false" id="559-d4c6-b2e8-500f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule can be fielded as a ‘detachment’ (see page 282).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be fielded as a ‘detachment’ (see page 282).</characteristic>
       </characteristics>
     </profile>
     <profile name="Ambushers" hidden="false" id="8c0b-6fe6-dc06-512" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule may be held in reserve rather than be deployed at the start of the game. From the
-          beginning of round two onwards, roll a D6 during each of your Start of Turn sub-phases for
-          each unit of Ambushers in your army that is held in reserve. On a roll of 1-3, the unit is
-          delayed until your next turn at least. On a roll of 4+, the unit arrives, entering the
-          battle as reinforcements during the Compulsory Moves sub-phase. The unit may be placed on
-          any edge of the battlefield, chosen by its controlling player, but cannot be placed within
-          8&quot; of an enemy model. If any Ambushers are still held in reserve by the start of
-          round five, they arrive automatically.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may be held in reserve rather than be deployed at the start of the game. From the beginning of round two onwards, roll a D6 during each of your Start of Turn sub-phases for each unit of Ambushers in your army that is held in reserve. On a roll of 1-3, the unit is delayed until your next turn at least. On a roll of 4+, the unit arrives, entering the battle as reinforcements during the Compulsory Moves sub-phase. The unit may be placed on any edge of the battlefield, chosen by its controlling player, but cannot be placed within 8&quot; of an enemy model. If any Ambushers are still held in reserve by the start of round five, they arrive automatically.</characteristic>
       </characteristics>
     </profile>
     <profile name="Vanguard" hidden="false" id="691e-10ec-4f7c-a2c4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment, units with
-          this special rule may make a Vanguard move. A unit making a Vanguard move moves as
-          described in the Basic Movement rules. It may manoeuvre normally but cannot march.
-          If both armies contain Vanguard units, a roll-off determines who moves first. The players
-          then alternate moving their Vanguard units one at a time, starting with the player who won
-          the roll-off.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">After deployment, units with this special rule may make a Vanguard move. A unit making a Vanguard move moves as described in the Basic Movement rules. It may manoeuvre normally but cannot march.
+If both armies contain Vanguard units, a roll-off determines who moves first. The players then alternate moving their Vanguard units one at a time, starting with the player who won the roll-off.</characteristic>
       </characteristics>
     </profile>
     <profile name="Warband" hidden="false" id="505f-e12d-2e36-31d0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a
-          Warband gains a positive (+) modifier to its Leadership characteristic equal to its
-          current Rank Bonus, up to a maximum of Leadership 10. However, a Warband cannot use this
-          modifier to its Leadership should it ever choose to make a Restraint test. In addition, if
-          the majority of the models in a unit have this special rule, it may re-roll its Charge
-          roll.
-          Note that unless a character also has this special rule, their Leadership cannot be
-          modified by this special rule. A Warband can use either its own modified Leadership, the
-          modified Leadership of a Warband character, or the unmodified Leadership of a non-Warband
-          character, whichever is the higher.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Warband gains a positive (+) modifier to its Leadership characteristic equal to its current Rank Bonus, up to a maximum of Leadership 10. However, a Warband cannot use this modifier to its Leadership should it ever choose to make a Restraint test. In addition, if the majority of the models in a unit have this special rule, it may re-roll its Charge roll.
+Note that unless a character also has this special rule, their Leadership cannot be modified by this special rule. A Warband can use either its own modified Leadership, the modified Leadership of a Warband character, or the unmodified Leadership of a non-Warband character, whichever is the higher.</characteristic>
       </characteristics>
     </profile>
     <profile name="Impetuous" hidden="false" id="b664-8530-a988-7ba9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If during the Declare
-          Charges &amp; Charge Reactions sub-phase of its turn, a unit that includes one or more
-          Impetuous models is able to declare a charge, roll a D6. On a roll of 1-3, the unit must
-          declare a charge. On a roll of 4+, the unit may act as normal.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If during the Declare Charges &amp; Charge Reactions sub-phase of its turn, a unit that includes one or more Impetuous models is able to declare a charge, roll a D6. On a roll of 1-3, the unit must declare a charge. On a roll of 4+, the unit may act as normal.</characteristic>
       </characteristics>
     </profile>
     <profile name="Light Armour" hidden="false" id="dbb2-4d85-84c2-528c" typeId="c14f-740-8107-d34b" typeName="Armour">
@@ -448,19 +405,12 @@
     </profile>
     <profile name="Frenzy" hidden="false" id="3b0c-a477-8823-3a25" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="170" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Frenzied model has a +1
-          modifier to its Attacks characteristic. This modifier does not apply to the model’s mount
-          (in the case of a cavalry model), to the beasts that draw it (in the case of a chariot),
-          or to its rider (in the case of a monster).
-          In addition:
-          • If the majority of the models in a unit are Frenzied, the unit automatically passes any
-          Fear, Panic or Terror tests it is required to make.
-          • If a unit that includes one or more Frenzied models is able to declare a charge during
-          the Declare Charges &amp; Charge Reactions sub-phase of its turn, it must do so.
-          • If the majority of the models in a unit are Frenzied, it cannot choose to Flee as a
-          charge reaction, nor can it ever choose to make a Restraint test.
-          Losing Frenzy: Unlike other special rules, Frenzy can be lost during a game. Any model
-          that loses a round of combat will immediately lose this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A Frenzied model has a +1 modifier to its Attacks characteristic. This modifier does not apply to the model’s mount (in the case of a cavalry model), to the beasts that draw it (in the case of a chariot), or to its rider (in the case of a monster).
+In addition:
+•	If the majority of the models in a unit are Frenzied, the unit automatically passes any Fear, Panic or Terror tests it is required to make.
+•	If a unit that includes one or more Frenzied models is able to declare a charge during the Declare Charges &amp; Charge Reactions sub-phase of its turn, it must do so.
+•	If the majority of the models in a unit are Frenzied, it cannot choose to Flee as a charge reaction, nor can it ever choose to make a Restraint test.
+Losing Frenzy: Unlike other special rules, Frenzy can be lost during a game. Any model that loses a round of combat will immediately lose this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Armour Bane" hidden="false" id="2af0-975f-bb14-8b8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -488,77 +438,43 @@
     </profile>
     <profile name="Breath Weapon" hidden="false" id="e049-8b4d-23e9-7505" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="166" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with a Breath Weapon
-          can use it once per round, during the Shooting phase of its turn. Place the flame template
-          with its broad end over the intended target and its narrow end touching the model’s base
-          edge anywhere along its front arc. The template must lie entirely within the model’s
-          vision arc. Any model whose base lies underneath the template risks being hit, as
-          described on page 95. The Strength and any special rules of the breath weapon will be
-          detailed in the creature’s rules.
-          Breath weapons cannot be used when making a Stand &amp; Shoot charge reaction, or when the
-          model is engaged in combat.
-          The flame template is placed with the narrow end touching the model’s base edge, within
-          its forward arc, and the broad end over the target unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with a Breath Weapon can use it once per round, during the Shooting phase of its turn. Place the flame template with its broad end over the intended target and its narrow end touching the model’s base edge anywhere along its front arc. The template must lie entirely within the model’s vision arc. Any model whose base lies underneath the template risks being hit, as described on page 95. The Strength and any special rules of the breath weapon will be detailed in the creature’s rules.
+Breath weapons cannot be used when making a Stand &amp; Shoot charge reaction, or when the model is engaged in combat.
+The flame template is placed with the narrow end touching the model’s base edge, within its forward arc, and the broad end over the target unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Counter Charge" hidden="false" id="5186-798d-69d-6545" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">This special rule can only
-          be used by units that consist entirely of models with this special rule. When a unit with
-          this special rule is charged in its front arc by an enemy unit whose troop type is
-          ‘cavalry,’ ‘chariot’ or ‘monster’, it may declare a ‘Counter Charge’ charge reaction:
-          Counter Charge: The unit surges forward to meet the enemy charge. Measure the distance
-          between the two units. If the distance is less than the Movement characteristic of the
-          charging unit, the charged unit has not enough time to meet the enemy charge and must
-          either Hold or Flee instead.
-          Otherwise, pivot the unit about its centre so that it is facing directly towards the
-          centre of the charging enemy unit. After pivoting, the unit moves D3+1&quot; directly
-          towards the enemy unit. Both units are considered to have charged during this turn.
-          Fleeing units and units already engaged in combat when charged cannot Counter Charge. A
-          unit can only Counter Charge in response to one charge per turn, even if charged by
-          multiple units. Once all charges have been declared, the inactive player can choose which
-          charging unit to Counter Charge. The unit will then Hold against the other charging units.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This special rule can only be used by units that consist entirely of models with this special rule. When a unit with this special rule is charged in its front arc by an enemy unit whose troop type is ‘cavalry,’ ‘chariot’ or ‘monster’, it may declare a ‘Counter Charge’ charge reaction:
+Counter Charge: The unit surges forward to meet the enemy charge. Measure the distance between the two units. If the distance is less than the Movement characteristic of the charging unit, the charged unit has not enough time to meet the enemy charge and must either Hold or Flee instead.
+Otherwise, pivot the unit about its centre so that it is facing directly towards the centre of the charging enemy unit. After pivoting, the unit moves D3+1&quot; directly towards the enemy unit. Both units are considered to have charged during this turn.
+Fleeing units and units already engaged in combat when charged cannot Counter Charge. A unit can only Counter Charge in response to one charge per turn, even if charged by multiple units. Once all charges have been declared, the inactive player can choose which charging unit to Counter Charge. The unit will then Hold against the other charging units.</characteristic>
       </characteristics>
     </profile>
     <profile name="Cumbersome" hidden="false" id="9db1-2d1d-b6dd-6ff1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Weapons with this special
-          rule cannot be used when making a Stand &amp; Shoot charge reaction.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Weapons with this special rule cannot be used when making a Stand &amp; Shoot charge reaction.</characteristic>
       </characteristics>
     </profile>
     <profile name="Dragged Along" hidden="false" id="a042-c2f5-ebcb-2bab" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special
-          rule that begins its movement within 1&quot; of a friendly unit whose troop type is
-          ‘infantry,’ that is not fleeing and that contains ten or more models, may replace its
-          Movement characteristic with that of the unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule that begins its movement within 1&quot; of a friendly unit whose troop type is ‘infantry,’ that is not fleeing and that contains ten or more models, may replace its Movement characteristic with that of the unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Drilled" hidden="false" id="1f64-3ddc-db58-12fb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a
-          Drilled unit may perform a free redress the ranks manoeuvre immediately before moving.
-          Once this manoeuvre is complete, the unit moves as normal. In addition, a Drilled unit can
-          march whilst within 8&quot; of an enemy unit without first having to make a Leadership
-          test.
-          Note that any character that joins a Drilled unit is considered to be Drilled as well.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is fleeing, a Drilled unit may perform a free redress the ranks manoeuvre immediately before moving. Once this manoeuvre is complete, the unit moves as normal. In addition, a Drilled unit can march whilst within 8&quot; of an enemy unit without first having to make a Leadership test.
+Note that any character that joins a Drilled unit is considered to be Drilled as well.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ethereal" hidden="false" id="6561-8029-dac3-162" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Ethereal creatures treat all
-          terrain as open ground for the purposes of movement. They cannot end their movement inside
-          impassable terrain, though they can pass through it. In addition, Ethereal creatures can
-          only be wounded by Magical attacks. Characters that are not Ethereal cannot join units
-          that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Ethereal creatures treat all terrain as open ground for the purposes of movement. They cannot end their movement inside impassable terrain, though they can pass through it. In addition, Ethereal creatures can only be wounded by Magical attacks. Characters that are not Ethereal cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Evasive" hidden="false" id="9fff-999f-6e96-e149" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, when this
-          unit is declared the target during the enemy Shooting phase, it may choose to Fall Back in
-          Good Order and will flee directly away from the enemy unit shooting at it. Once this unit
-          has completed its move, the enemy unit may continue with its shooting as declared.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Once per turn, when this unit is declared the target during the enemy Shooting phase, it may choose to Fall Back in Good Order and will flee directly away from the enemy unit shooting at it. Once this unit has completed its move, the enemy unit may continue with its shooting as declared.</characteristic>
       </characteristics>
     </profile>
     <profile name="Extra Attacks" hidden="false" id="23c7-1aeb-5f02-c9e1" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -571,79 +487,48 @@
     </profile>
     <profile name="Fast Cavalry" hidden="false" id="df-a39-e62-1c57" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If all of the models
-          (including characters) within a unit arrayed in an Open Order formation have this special
-          rule, the unit may perform its Quick Turn (see page 183) even if it marched.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If all of the models (including characters) within a unit arrayed in an Open Order formation have this special rule, the unit may perform its Quick Turn (see page 183) even if it marched.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fear" hidden="false" id="5ec9-a98-d8c5-e18b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule cause Fear:
-          • If a unit wishes to declare a charge against an enemy unit that both causes Fear and has
-          a higher Unit Strength, it must first make a Leadership test. If this test is failed, the
-          unit cannot charge. It does not move and is considered to have made a failed charge. If
-          this test is passed, the unit can charge as normal.
-          • If a unit is engaged with an enemy unit that both causes Fear and has a higher Unit
-          Strength when its combat is chosen during any Choose &amp; Fight Combat sub-phase, it must
-          make a Leadership test. If this test is failed, any models in the unit that direct their
-          attacks against the Fear-causing enemy suffer a -1 modifier to their rolls To Hit.
-          A unit only needs to make one Fear test per turn. Models that cause Fear are immune to
-          Fear. A unit that does not cause Fear does not become immune to Fear when joined by a
-          character that does.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Fear:
+•	If a unit wishes to declare a charge against an enemy unit that both causes Fear and has a higher Unit Strength, it must first make a Leadership test. If this test is failed, the unit cannot charge. It does not move and is considered to have made a failed charge. If this test is passed, the unit can charge as normal.
+•	If a unit is engaged with an enemy unit that both causes Fear and has a higher Unit Strength when its combat is chosen during any Choose &amp; Fight Combat sub-phase, it must make a Leadership test. If this test is failed, any models in the unit that direct their attacks against the Fear-causing enemy suffer a -1 modifier to their rolls To Hit.
+A unit only needs to make one Fear test per turn. Models that cause Fear are immune to Fear. A unit that does not cause Fear does not become immune to Fear when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
     <profile name="Feigned Flight" hidden="false" id="eea7-89d9-a996-403c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="168" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit chooses to Flee
-          (or Fire &amp; Flee) as a charge reaction, it automatically rallies at the end of its
-          move, as described on page 117.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit chooses to Flee (or Fire &amp; Flee) as a charge reaction, it automatically rallies at the end of its move, as described on page 117.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fight In Extra Rank" hidden="false" id="b49e-b47f-fb38-596e" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special
-          rule may make a supporting attack, as described on page 145.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule may make a supporting attack, as described on page 145.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fire &amp; Flee" hidden="false" id="1a06-31aa-cbfe-1a5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule that is also armed with missile weapons may declare that it will ‘Fire &amp; Flee’ as
-          a charge reaction:
-          Fire &amp; Flee: The unit launches a volley of weapons fire before turning to flee from
-          the enemy. If a unit with this special rule is armed with missile weapons and can draw a
-          line of sight to the charging unit, it may declare that it will Fire &amp; Flee. The unit
-          will Stand &amp; Shoot (as described on page 120) before turning tail and fleeing from the
-          charge. However, due to the time spent shooting at the charging foe, when making its Flee
-          roll the unit rolls two D6 and discards the lowest result. If both dice roll the same
-          result, discard either.
-          Note that, if the distance between this unit and the charging unit is less than the
-          Movement characteristic of the charging unit, this unit must either Hold or Flee.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule that is also armed with missile weapons may declare that it will ‘Fire &amp; Flee’ as a charge reaction:
+Fire &amp; Flee: The unit launches a volley of weapons fire before turning to flee from the enemy. If a unit with this special rule is armed with missile weapons and can draw a line of sight to the charging unit, it may declare that it will Fire &amp; Flee. The unit will Stand &amp; Shoot (as described on page 120) before turning tail and fleeing from the charge. However, due to the time spent shooting at the charging foe, when making its Flee roll the unit rolls two D6 and discards the lowest result. If both dice roll the same result, discard either.
+Note that, if the distance between this unit and the charging unit is less than the Movement characteristic of the charging unit, this unit must either Hold or Flee.</characteristic>
       </characteristics>
     </profile>
     <profile name="First Charge" hidden="false" id="785a-2886-af42-dce9" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit’s first charge
-          of the game is successful (i.e., if the unit makes contact with the charge target), the
-          charge target becomes Disrupted until the end of the Combat phase of that turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit’s first charge of the game is successful (i.e., if the unit makes contact with the charge target), the charge target becomes Disrupted until the end of the Combat phase of that turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Flaming Attacks" hidden="false" id="e45d-952-f679-ae2c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hits
-          caused by a model with this special rule, or made using a weapon or spell with this
-          special rule, is a ‘Flaming’ attack. In addition, a model with this special rule causes
-          Fear (as described on page 168) in models whose troop type is ‘war beasts’ or ‘swarms’.
-          Unless otherwise stated, a model with this special rule makes Flaming attacks both when
-          shooting and in combat (though any spells cast by the model are unaffected, as are any
-          attacks made with magic weapons they might be wielding).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hits caused by a model with this special rule, or made using a weapon or spell with this special rule, is a ‘Flaming’ attack. In addition, a model with this special rule causes Fear (as described on page 168) in models whose troop type is ‘war beasts’ or ‘swarms’.
+Unless otherwise stated, a model with this special rule makes Flaming attacks both when shooting and in combat (though any spells cast by the model are unaffected, as are any attacks made with magic weapons they might be wielding).</characteristic>
       </characteristics>
     </profile>
     <profile name="Flammable" hidden="false" id="8f64-6d4c-466b-1b94" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="169" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special
-          rule cannot make a Regeneration save against a wound caused by a Flaming attack.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Flaming attack.</characteristic>
       </characteristics>
     </profile>
     <profile name="Fly" hidden="false" id="c557-6102-9a35-bbcd" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -669,111 +554,66 @@
     </profile>
     <profile name="Furious Charge" hidden="false" id="eaca-69a2-8b6a-81c6" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it
-          made a charge move of 3&quot; or more, a model with this special rule gains a +1 modifier
-          to its Attacks characteristic.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During a turn in which it made a charge move of 3&quot; or more, a model with this special rule gains a +1 modifier to its Attacks characteristic.</characteristic>
       </characteristics>
     </profile>
     <profile name="Horde" hidden="false" id="9cba-89a5-1796-5fe4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule may increase the maximum Rank Bonus it can claim (as determined by its troop type) by
-          one.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule may increase the maximum Rank Bonus it can claim (as determined by its troop type) by one.</characteristic>
       </characteristics>
     </profile>
     <profile name="Ignores Cover" hidden="false" id="a401-372d-446e-d27c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model making a shooting
-          attack has this special rule, it ignores any To Hit modifiers caused by partial or full
-          cover.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model making a shooting attack has this special rule, it ignores any To Hit modifiers caused by partial or full cover.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Immune to Psychology" hidden="false" id="93d9-c75b-f655-30ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Immune To Psychology" hidden="false" id="93d9-c75b-f655-30ac" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the
-          models in a unit are Immune to Psychology, the unit automatically passes any Fear, Panic
-          or Terror tests it is required to make. However, if the majority of the models in a unit
-          have this special rule, the unit cannot choose to Flee as a charge reaction.
-          Note that this special rule does not make a unit immune to any test made against
-          Leadership not stated here.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If the majority of the models in a unit are Immune to Psychology, the unit automatically passes any Fear, Panic or Terror tests it is required to make. However, if the majority of the models in a unit have this special rule, the unit cannot choose to Flee as a charge reaction.
+Note that this special rule does not make a unit immune to any test made against Leadership not stated here.</characteristic>
       </characteristics>
     </profile>
     <profile name="Killing Blow" hidden="false" id="860b-e13a-4710-9bf0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special
-          rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has
-          struck a ‘Killing Blow’. Enemy models whose troop type is ‘infantry’ or ‘cavalry’ are not
-          permitted an armour or Regeneration save (see page 176) against a Killing Blow (Ward saves
-          can be attempted as normal). If an enemy model whose troop type is ‘infantry’ or ‘cavalry’
-          suffers an unsaved wound from a Killing Blow, it loses all of its remaining Wounds.
-          Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ‘Killing Blow’. Enemy models whose troop type is ‘infantry’ or ‘cavalry’ are not permitted an armour or Regeneration save (see page 176) against a Killing Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is ‘infantry’ or ‘cavalry’ suffers an unsaved wound from a Killing Blow, it loses all of its remaining Wounds.
+Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="Levies" hidden="false" id="8cc3-d6f5-da17-6600" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule cannot use the Inspiring Presence rule of the army’s General nor the Hold your Ground
-          rule of a Battle Standard. However, little is expected from Levies in battle. Therefore,
-          units that do not have this special rule are not required to make a Panic test when a
-          friendly unit of Levies Breaks and flees from combat.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cannot use the Inspiring Presence rule of the army’s General nor the Hold your Ground rule of a Battle Standard. However, little is expected from Levies in battle. Therefore, units that do not have this special rule are not required to make a Panic test when a friendly unit of Levies Breaks and flees from combat.</characteristic>
       </characteristics>
     </profile>
     <profile name="Loner" hidden="false" id="2ecd-c6b3-bd8b-864b" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this
-          special rule cannot be your General and cannot join a unit without this special rule. A
-          unit with this special rule cannot be joined by a character without this special rule.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A character with this special rule cannot be your General and cannot join a unit without this special rule. A unit with this special rule cannot be joined by a character without this special rule.</characteristic>
       </characteristics>
     </profile>
     <profile name="Magical Attacks" hidden="false" id="2125-6aa2-f782-42bf" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hit
-          caused by a model with this special rule, or made using a weapon with this special rule,
-          is a ‘Magical’ attack.
-          Note that all spells are considered to have this special rule, as are any hits caused by
-          magic items.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Any attack made or hit caused by a model with this special rule, or made using a weapon with this special rule, is a ‘Magical’ attack.
+Note that all spells are considered to have this special rule, as are any hits caused by magic items.</characteristic>
       </characteristics>
     </profile>
     <profile name="Mercenaries" hidden="false" id="4d1b-2617-ebdc-4f4d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Often, an army can include
-          certain units drawn from another army list as mercenaries. Any such units included in your
-          army gain this special rule. Mercenaries cannot use the Inspiring Presence rule of the
-          army’s General (see page 203) nor the Hold your Ground rule of a Battle Standard (see page
-          203). Mercenaries cannot be joined by characters drawn from another army list.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Often, an army can include certain units drawn from another army list as mercenaries. Any such units included in your army gain this special rule. Mercenaries cannot use the Inspiring Presence rule of the army’s General (see page 203) nor the Hold your Ground rule of a Battle Standard (see page 203). Mercenaries cannot be joined by characters drawn from another army list.</characteristic>
       </characteristics>
     </profile>
     <profile name="Monster Handlers" hidden="false" id="1084-a4e9-79f-3462" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A monster with this special
-          rule is accompanied by one or more models representing its handlers. During deployment,
-          position these models anywhere that is adjacent to, and in base contact with, the monster.
-          If the handlers are found to be blocking movement or line of sight, simply move them
-          aside.
-          In combat, each handler adds its attacks to those of the monster. If the monster suffers
-          an unsaved wound, roll a D6. On a roll of 1-4 the monster loses a Wound, but on a roll of
-          5+ a handler model suffers the wound instead. If the monster is removed from play, so are
-          its handlers.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A monster with this special rule is accompanied by one or more models representing its handlers. During deployment, position these models anywhere that is adjacent to, and in base contact with, the monster. If the handlers are found to be blocking movement or line of sight, simply move them aside.
+In combat, each handler adds its attacks to those of the monster. If the monster suffers an unsaved wound, roll a D6. On a roll of 1-4 the monster loses a Wound, but on a roll of 5+ a handler model suffers the wound instead. If the monster is removed from play, so are its handlers.</characteristic>
       </characteristics>
     </profile>
     <profile name="Chariot Runners" hidden="false" id="afa3-a46a-2608-f62c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="167" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Friendly models whose troop
-          type is ‘chariot’ can draw a line of sight over or through models with this special rule
-          and can move through friendly units of Chariot Runners that are in Skirmish formation. If
-          the chariot’s move would result in it ending up ‘on top’ of a Chariot Runner, simply nudge
-          the Chariot Runner aside, by the smallest amount possible, to make space for the chariot.
-          Whilst in Skirmish formation units of Chariot Runners can treat friendly chariots that are
-          within 1&quot; of one or more of the unit’s models as a part of the unit for the purposes
-          of unit coherency.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Friendly models whose troop type is ‘chariot’ can draw a line of sight over or through models with this special rule and can move through friendly units of Chariot Runners that are in Skirmish formation. If the chariot’s move would result in it ending up ‘on top’ of a Chariot Runner, simply nudge the Chariot Runner aside, by the smallest amount possible, to make space for the chariot. Whilst in Skirmish formation units of Chariot Runners can treat friendly chariots that are within 1&quot; of one or more of the unit’s models as a part of the unit for the purposes of unit coherency.</characteristic>
       </characteristics>
     </profile>
     <profile name="Howdah" hidden="false" id="b8f6-1cbc-b19-c7b7" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="171" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">To represent its howdah and
-          crew, a behemoth with this special rule has a split profile and follows both the ‘Split
-          Profile (Chariots)’ and ‘Firing Platform’ rules (see page 194). In all other respects,
-          this model is a behemoth.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">To represent its howdah and crew, a behemoth with this special rule has a split profile and follows both the ‘Split Profile (Chariots)’ and ‘Firing Platform’ rules (see page 194). In all other respects, this model is a behemoth.</characteristic>
       </characteristics>
     </profile>
     <profile name="Impact Hits" hidden="false" id="5c2-e9dd-2715-a0c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -790,60 +630,31 @@
     </profile>
     <profile name="Large Target" hidden="false" id="c822-7ad0-f24a-e4af" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="172" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models never suffer To
-          Hit modifiers for full or partial cover when shooting at models with this special rule. In
-          addition, a model can draw a line of sight to a model with this special rule over or
-          through other models, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Enemy models never suffer To Hit modifiers for full or partial cover when shooting at models with this special rule. In addition, a model can draw a line of sight to a model with this special rule over or through other models, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Monster Slayer" hidden="false" id="6b2f-7ce0-3e27-4ded" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="173" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special
-          rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has
-          struck a ‘Monster Slaying Blow’. Enemy models whose troop type is ‘monster’ are not
-          permitted an armour or Regeneration save (see page 176) against a Monster Slaying Blow
-          (Ward saves can be attempted as normal). If an enemy model whose troop type is ‘monster’
-          suffers an unsaved wound from a Monster Slaying Blow, it loses all of its remaining
-          Wounds.
-          Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a model with this special rule rolls a natural 6 when making a roll To Wound for an attack made in combat, it has struck a ‘Monster Slaying Blow’. Enemy models whose troop type is ‘monster’ are not permitted an armour or Regeneration save (see page 176) against a Monster Slaying Blow (Ward saves can be attempted as normal). If an enemy model whose troop type is ‘monster’ suffers an unsaved wound from a Monster Slaying Blow, it loses all of its remaining Wounds.
+Note that if an attack wounds automatically, this special rule cannot be used.</characteristic>
       </characteristics>
     </profile>
     <profile name="Motley Crew" hidden="false" id="6359-4018-5cd4-3720" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule
-          may include models of the same type that are equipped differently to one another, and/or
-          models of different types that fight together in a single unit. If necessary, the army
-          list entry for such units will be accompanied by a brief explanation of the unit’s
-          composition.
-          Different Weapons: The fighting rank of a Motley Crew may contain models that are armed
-          with different weapons. In such cases, the controlling player must roll different batches
-          of dice for the different models, making it clear to their opponent which model’s attacks
-          they represent and where they are being directed. These attacks are made in the Initiative
-          order of the individual models, as usual.
-          Different Armour: Models within a Motley Crew may have different armour values. In combat,
-          use the armour value of the majority of the models in the fighting rank. Against enemy
-          shooting, use the armour value of the majority of the models in the unit.
-          Casualty Removal: Against enemy shooting, casualty removal should be divided as equally as
-          possible between the different models within the unit. In combat, casualties should be
-          removed from among the majority of the models that make up the fighting rank. In either
-          case, available models are brought forward from rear ranks to fill any gaps, as chosen by
-          the controlling player.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Units with this special rule may include models of the same type that are equipped differently to one another, and/or models of different types that fight together in a single unit. If necessary, the army list entry for such units will be accompanied by a brief explanation of the unit’s composition.
+Different Weapons: The fighting rank of a Motley Crew may contain models that are armed with different weapons. In such cases, the controlling player must roll different batches of dice for the different models, making it clear to their opponent which model’s attacks they represent and where they are being directed. These attacks are made in the Initiative order of the individual models, as usual.
+Different Armour: Models within a Motley Crew may have different armour values. In combat, use the armour value of the majority of the models in the fighting rank. Against enemy shooting, use the armour value of the majority of the models in the unit.
+Casualty Removal: Against enemy shooting, casualty removal should be divided as equally as possible between the different models within the unit. In combat, casualties should be removed from among the majority of the models that make up the fighting rank. In either case, available models are brought forward from rear ranks to fill any gaps, as chosen by the controlling player.</characteristic>
       </characteristics>
     </profile>
     <profile name="Move &amp; Shoot" hidden="false" id="6d4e-d525-ad86-4e4a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special
-          rule can be used in the Shooting phase even if the model equipped with it marched this
-          turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule can be used in the Shooting phase even if the model equipped with it marched this turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Rallying Cry" hidden="false" id="23c4-bd19-2422-ad08" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase
-          of their turn, if they are not engaged in combat, this character may nominate a single
-          fleeing friendly unit that is within their Command range. The nominated unit immediately
-          makes a Rally test. If this test is failed, the unit may attempt to rally again as normal
-          during the Rally sub-phase.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Command sub-phase of their turn, if they are not engaged in combat, this character may nominate a single fleeing friendly unit that is within their Command range. The nominated unit immediately makes a Rally test. If this test is failed, the unit may attempt to rally again as normal during the Rally sub-phase.</characteristic>
       </characteristics>
     </profile>
     <profile name="Quick Shot" hidden="false" id="f733-b74b-6cb1-c69" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
@@ -856,8 +667,7 @@
     </profile>
     <profile name="Ponderous" hidden="false" id="1170-9414-b4b5-a125" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="175" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special
-          rule suffers a To Hit modifier of -2 for Moving and Shooting, rather than the usual -1.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule suffers a To Hit modifier of -2 for Moving and Shooting, rather than the usual -1.</characteristic>
       </characteristics>
     </profile>
     <profile name="Multiple Wounds" hidden="false" id="e3d3-a090-9e2-b276" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -873,11 +683,9 @@
           &apos;spill over&apos; onto other models in the unit.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Move or Shoot" hidden="false" id="f384-89df-fa9b-1d33" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Move Or Shoot" hidden="false" id="f384-89df-fa9b-1d33" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="174" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special
-          rule cannot be used in the Shooting phase if the model equipped with it moved for any
-          reason during this turn (including rallying and reforming).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A weapon with this special rule cannot be used in the Shooting phase if the model equipped with it moved for any reason during this turn (including rallying and reforming).</characteristic>
       </characteristics>
     </profile>
     <profile name="Multiple Shots" hidden="false" id="11ef-2de2-ef4c-dc56" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -897,29 +705,14 @@
     </profile>
     <profile name="Random Attacks" hidden="false" id="1b08-4621-6379-ff1f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule do not have a normal Attacks characteristic. Instead, a dice roll is given (D3+1, for
-          example). Each time a model with this special rule attacks in combat, roll the dice to
-          determine the number of attacks it will make, then roll To Hit as normal. If a fighting
-          rank contains more than one model with this special rule, roll separately for each, unless
-          specified otherwise.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Attacks characteristic. Instead, a dice roll is given (D3+1, for example). Each time a model with this special rule attacks in combat, roll the dice to determine the number of attacks it will make, then roll To Hit as normal. If a fighting rank contains more than one model with this special rule, roll separately for each, unless specified otherwise.</characteristic>
       </characteristics>
     </profile>
     <profile name="Random Movement" hidden="false" id="4924-fc1f-bcd-746a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule do not have a normal Movement characteristic. Instead, a dice roll is given (2D6, for
-          example). Whenever a model with this special rule moves (for any reason), roll the dice to
-          determine how far it must move.
-          Models with this special rule move during the Compulsory Moves sub-phase. They cannot
-          march or declare a charge. They can wheel to change direction, but cannot perform any
-          other manoeuvres. If the model is able to make contact with an enemy unit during the
-          Compulsory Moves sub-phase or whilst pursuing, it may do so and counts as having charged.
-          The model aligns against the enemy unit and stops moving. A unit charged in this way must
-          Hold.
-          If every model in a unit has this special rule, roll once for the entire unit. If two or
-          more models in a unit have different Random Movement characteristics, roll for each and
-          use the lowest result for the entire unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule do not have a normal Movement characteristic. Instead, a dice roll is given (2D6, for example). Whenever a model with this special rule moves (for any reason), roll the dice to determine how far it must move.
+Models with this special rule move during the Compulsory Moves sub-phase. They cannot march or declare a charge. They can wheel to change direction, but cannot perform any other manoeuvres. If the model is able to make contact with an enemy unit during the Compulsory Moves sub-phase or whilst pursuing, it may do so and counts as having charged. The model aligns against the enemy unit and stops moving. A unit charged in this way must Hold.
+If every model in a unit has this special rule, roll once for the entire unit. If two or more models in a unit have different Random Movement characteristics, roll for each and use the lowest result for the entire unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Regeneration" hidden="false" id="2eb0-1ec8-8e04-72d4" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -931,8 +724,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
     </profile>
     <profile name="Regimental Unit" hidden="false" id="7424-ec43-7581-965a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule can be accompanied by ‘detachments’ (see page 282).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can be accompanied by ‘detachments’ (see page 282).</characteristic>
       </characteristics>
     </profile>
     <profile name="Requires Two Hands" hidden="false" id="4f8d-35e-6be9-dabb" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="176" publicationId="768b-3da1-a182-a1d8">
@@ -944,11 +736,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
     </profile>
     <profile name="Reserve Move" hidden="false" id="1f10-d7d-be19-7e8f" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it charged, marched
-          or fled during the Movement phase of its turn, a unit with this special rule may make a
-          Reserve move at the end of the Shooting phase of its turn, after all shooting has been
-          resolved. A unit making a Reserve move moves as described in the Basic Movement rules. It
-          may manoeuvre normally, but cannot march.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it charged, marched or fled during the Movement phase of its turn, a unit with this special rule may make a Reserve move at the end of the Shooting phase of its turn, after all shooting has been resolved. A unit making a Reserve move moves as described in the Basic Movement rules. It may manoeuvre normally, but cannot march.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stomp Attacks" hidden="false" id="72db-24bb-7493-d753" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
@@ -965,134 +753,95 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
     </profile>
     <profile name="Strike First" hidden="false" id="48fd-23c1-c0d5-ae1d" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="177" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a
-          model with this special rule that is engaged in combat improves its Initiative
-          characteristic to 10 (before any other modifiers are applied). If a model has both this
-          rule and Strike Last, the two rules cancel one another out.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rule that is engaged in combat improves its Initiative characteristic to 10 (before any other modifiers are applied). If a model has both this rule and Strike Last, the two rules cancel one another out.</characteristic>
       </characteristics>
     </profile>
     <profile name="Strike Last" hidden="false" id="7c4d-72c1-eeb-ab5c" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a
-          model with this special rule that is engaged in combat reduces its Initiative
-          characteristic to 1 (before any other modifiers are applied). If a model has both this
-          rule and Strike First, the two rules cancel one another out.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">During the Combat phase, a model with this special rule that is engaged in combat reduces its Initiative characteristic to 1 (before any other modifiers are applied). If a model has both this rule and Strike First, the two rules cancel one another out.</characteristic>
       </characteristics>
     </profile>
     <profile name="Stupidity" hidden="false" id="f7af-e016-1f9c-54c0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is engaged in
-          combat, a unit with this special rule must make a ‘Stupidity’ test during the Start of
-          Turn sub-phase of its turn. To make a Stupidity test, test against the unit’s Leadership
-          characteristic. If this test is failed, the unit becomes Stupid. A Stupid unit:
-          • Moves during the Compulsory Moves sub-phase.
-          • Must move straight ahead, without performing any manoeuvres.
-          • Cannot march or declare a charge.
-          A unit or mount that does not have this special rule becomes subject to it when joined or
-          ridden by a character that does (Stupidity is contagious).</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Unless it is engaged in combat, a unit with this special rule must make a ‘Stupidity’ test during the Start of Turn sub-phase of its turn. To make a Stupidity test, test against the unit’s Leadership characteristic. If this test is failed, the unit becomes Stupid. A Stupid unit:
+•	Moves during the Compulsory Moves sub-phase.
+•	Must move straight ahead, without performing any manoeuvres.
+•	Cannot march or declare a charge.
+A unit or mount that does not have this special rule becomes subject to it when joined or ridden by a character that does (Stupidity is contagious).</characteristic>
       </characteristics>
     </profile>
     <profile name="Swiftstride" hidden="false" id="dc91-48b3-3696-217" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="178" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special
-          rule increases its maximum possible charge range by 3&quot; and, when it makes a Charge,
-          Flee or Pursuit roll, may apply a +D6 modifier to the result.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule increases its maximum possible charge range by 3&quot; and, when it makes a Charge, Flee or Pursuit roll, may apply a +D6 modifier to the result.</characteristic>
       </characteristics>
     </profile>
     <profile name="Terror" hidden="false" id="c7a2-35bf-4313-f4f0" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special
-          rule cause Terror. Models that cause Terror also cause Fear, as described on page 168:
-          • When a unit that causes Terror declares a charge, the charge target must immediately
-          make a Leadership test. If this test is failed, it must Flee. If this test is passed, it
-          can declare its charge reaction normally.
-          • If the winning side of a combat includes one or more units that cause Terror, each unit
-          that belongs to the losing side must apply a -1 modifier to its Leadership characteristic
-          when making its Break test.
-          Note that if a charged unit cannot choose to Flee, it does not make this Leadership test.
-          Models with the Fear special rule Fear models that cause Terror. Models that cause Terror
-          are immune to Terror. A unit that does not cause Terror does not become immune to Terror
-          when joined by a character that does.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">Models with this special rule cause Terror. Models that cause Terror also cause Fear, as described on page 168:
+•	When a unit that causes Terror declares a charge, the charge target must immediately make a Leadership test. If this test is failed, it must Flee. If this test is passed, it can declare its charge reaction normally.
+•	If the winning side of a combat includes one or more units that cause Terror, each unit that belongs to the losing side must apply a -1 modifier to its Leadership characteristic when making its Break test.
+Note that if a charged unit cannot choose to Flee, it does not make this Leadership test.
+Models with the Fear special rule Fear models that cause Terror. Models that cause Terror are immune to Terror. A unit that does not cause Terror does not become immune to Terror when joined by a character that does.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Timmm-berrr!" hidden="false" id="4f28-3f86-cf88-6b3a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Timmm-Berrr!" hidden="false" id="4f28-3f86-cf88-6b3a" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model is reduced
-          to zero Wounds, the winner of a roll-off chooses one of its arcs (front, flank or rear)
-          for it to fall into. Any units that are within the chosen arc and in base contact with
-          this model suffer D6 hits, each using the Strength characteristic of this model, with an
-          AP of -1. Once these hits are resolved, this model is removed from play.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When this model is reduced to zero Wounds, the winner of a roll-off chooses one of its arcs (front, flank or rear) for it to fall into. Any units that are within the chosen arc and in base contact with this model suffer D6 hits, each using the Strength characteristic of this model, with an AP of -1. Once these hits are resolved, this model is removed from play.</characteristic>
       </characteristics>
     </profile>
     <profile name="Unbreakable" hidden="false" id="d3eb-1fa0-bb19-f390" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="179" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special
-          rule loses a round of combat, it is not required to make a Break test. Instead, it will
-          automatically Give Ground as it is pushed back by the enemy. Characters that are not
-          Unbreakable cannot join units that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule loses a round of combat, it is not required to make a Break test. Instead, it will automatically Give Ground as it is pushed back by the enemy. Characters that are not Unbreakable cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warp-spawned" hidden="false" id="c24d-4386-c1ef-f195" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Warp-Spawned" hidden="false" id="c24d-4386-c1ef-f195" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special
-          rule cannot make a Regeneration save against a wound caused by a Magical attack. In
-          addition, characters that are not Warp-spawned cannot join units that are, and vice versa.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">A model with this special rule cannot make a Regeneration save against a wound caused by a Magical attack. In addition, characters that are not Warp-spawned cannot join units that are, and vice versa.</characteristic>
       </characteristics>
     </profile>
     <profile name="Volley Fire" hidden="false" id="330c-821e-8fe0-d4ae" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this
-          special rule makes a shooting attack, half of the models in each rank other than the front
-          rank (or front two ranks if the unit is on a hill), rounding up, can shoot (in addition to
-          the usual models that shoot from the front rank, or front two ranks if the unit is on a
-          hill). A unit cannot Volley Fire if it has moved for any reason during this turn
-          (including reforming), or when making a Stand &amp; Shoot charge reaction.
-          Note that models in rear ranks use the line of sight of the model at the front of their
-          file.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">When a unit with this special rule makes a shooting attack, half of the models in each rank other than the front rank (or front two ranks if the unit is on a hill), rounding up, can shoot (in addition to the usual models that shoot from the front rank, or front two ranks if the unit is on a hill). A unit cannot Volley Fire if it has moved for any reason during this turn (including reforming), or when making a Stand &amp; Shoot charge reaction.
+Note that models in rear ranks use the line of sight of the model at the front of their file.</characteristic>
       </characteristics>
     </profile>
     <profile name="Unstable" hidden="false" id="a10e-13b7-e959-ab5" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" page="180" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special
-          rule loses a round of combat, it loses one additional Wound for every combat result point
-          by which it lost. These Wounds are lost after combat results have been calculated but
-          before Break tests are made.
-          If an Unstable unit contains any Unstable characters, allocate wounds to the unit until
-          each model has been allocated one wound. Any remaining wounds are divided as equally as
-          possible between the character(s) and the unit.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If a unit with this special rule loses a round of combat, it loses one additional Wound for every combat result point by which it lost. These Wounds are lost after combat results have been calculated but before Break tests are made.
+If an Unstable unit contains any Unstable characters, allocate wounds to the unit until each model has been allocated one wound. Any remaining wounds are divided as equally as possible between the character(s) and the unit.</characteristic>
       </characteristics>
     </profile>
     <profile name="Standard Bearer" hidden="false" id="bcf8-d942-102e-b155" typeId="52d4-d959-fe4d-90fa" typeName="Command">
       <characteristics>
         <characteristic name="Description" typeId="441a-ef3a-c07e-95f">If a unit includes a standard
-          bearer, it may claim a bonus of +1 combat result point.
-          If a fleeing unit is run down by an enemy unit, or if a unit is destroyed in combat by an
-          enemy unit, its standard is claimed as a trophy. Standards claimed in this way are worth
-          bonus Victory Points at the end of the battle. Once a standard has been lost in this way,
+          bearer, it may claim a bonus of +1 combat result point.
+          If a fleeing unit is run down by an enemy unit, or if a unit is destroyed in combat by an
+          enemy unit, its standard is claimed as a trophy. Standards claimed in this way are worth
+          bonus Victory Points at the end of the battle. Once a standard has been lost in this way,
           it cannot be reclaimed.</characteristic>
       </characteristics>
     </profile>
     <profile name="Musician" hidden="false" id="40f2-dd77-f0ca-3663" typeId="52d4-d959-fe4d-90fa" typeName="Command">
       <characteristics>
         <characteristic name="Description" typeId="441a-ef3a-c07e-95f">If, once the combat result
-          has been calculated, both sides have the exact same number of points each, the side that
-          has a musician in the front rank of one or more of its units may claim a bonus of +1
-          combat result point. If, however, the opposing side has a musician also, the redoubled
-          efforts (and almighty clamour) cancel each other out and neither side may claim this
+          has been calculated, both sides have the exact same number of points each, the side that
+          has a musician in the front rank of one or more of its units may claim a bonus of +1
+          combat result point. If, however, the opposing side has a musician also, the redoubled
+          efforts (and almighty clamour) cancel each other out and neither side may claim this
           bonus.
-          If a fleeing unit contains a musician, it may apply a +1 modifier to its Leadership
-          characteristic whenever it attempts to rally, up to a maximum of Leadership 10.
-          Should a unit that contains a musician wish to march whilst within 8&quot; of an enemy
-          unit, it may apply a +1 modifier to its Leadership characteristic, up to a maximum of
-          Leadership10, when making its Leadership test.</characteristic>
+          If a fleeing unit contains a musician, it may apply a +1 modifier to its Leadership
+          characteristic whenever it attempts to rally, up to a maximum of Leadership 10.
+          Should a unit that contains a musician wish to march whilst within 8&quot; of an enemy
+          unit, it may apply a +1 modifier to its Leadership characteristic, up to a maximum of
+          Leadership10, when making its Leadership test.</characteristic>
       </characteristics>
     </profile>
     <profile name="Champion" hidden="false" id="5f1c-fd04-b0d5-d5e" typeId="52d4-d959-fe4d-90fa" typeName="Command">
       <characteristics>
         <characteristic name="Description" typeId="441a-ef3a-c07e-95f">In combat, a champion that is
-          within the fighting rank fights as normal. Enemy models that are in base contact with a
-          champion can direct attacks against that champion if they wish.
-          Champions can issue and accept challenges in the same manner as a character.</characteristic>
+          within the fighting rank fights as normal. Enemy models that are in base contact with a
+          champion can direct attacks against that champion if they wish.
+          Champions can issue and accept challenges in the same manner as a character.</characteristic>
       </characteristics>
     </profile>
     <profile name="Base (50x50)" typeId="1ae4-7f34-4055-fd5f" typeName="Base" hidden="false" id="7813-4d15-143d-1bf1">
@@ -1385,21 +1134,9 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
         <characteristic name="Description" typeId="adcd-c649-e6fc-a9f6">Base Armour value</characteristic>
       </characteristics>
     </profile>
-    <profile name="Battle Standard Bearer" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="da9a-f205-577f-debb">
+    <profile name="Battle Standard Bearer" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="da9a-f205-577f-debb" page="155" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Combat Result Bonus: A
-          Battle Standard grants a bonus of +1 combat result point. Unlike other standards, a
-          Battle Standard grants this bonus even if another standard is present. If, by some unusual
-          circumstance, there are two Battle Standards on the same side in the combat, you can only
-          count the bonus for one.
-
-
-          “Hold Your Ground”: To represent the Battle Standard’s steadying presence, unless your
-          Battle Standard Bearer is fleeing, friendly units within the Battle Standard Bearer’s
-          Command range may re-roll any failed Panic or Rally test. In addition, friendly units
-          within the Battle Standard Bearer’s Command range may re-roll the 2D6 when making a Break
-          test. However, you must accept the result of the second roll, even if it is worse than the
-          first.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">This army list is intended for use alongside the ‘Forming Units’ and ‘Warhammer Armies’ sections of the Warhammer: the Old World rulebook. Over the following pages you will find profiles and rules for each of the models in your army. These pages give you all of the information that you need to shape your collection of models into the units which will in turn form a force ready for battle.</characteristic>
       </characteristics>
     </profile>
     <profile name="Repeater Bolt Thrower" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="3f5c-8185-3494-86c1">

--- a/Warhammer_Old_World.gst
+++ b/Warhammer_Old_World.gst
@@ -140,7 +140,7 @@
         <characteristicType id="1adf-d238-57ca-2226" name="Base Size"/>
       </characteristicTypes>
     </profileType>
-    <profileType name="Weapon" hidden="false" id="cc88-6a7d-41c9-d63e" sortIndex="2">
+    <profileType name="Weapon (free-text) " hidden="false" id="cc88-6a7d-41c9-d63e" sortIndex="2">
       <characteristicTypes>
         <characteristicType id="47f2-ecee-cae0-9ef9" name="Description"/>
       </characteristicTypes>
@@ -204,7 +204,7 @@
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Hand Weapon" hidden="false" id="ef45-edcd-18bf-fe1d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="213" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Hand Weapon" hidden="false" id="ef45-edcd-18bf-fe1d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="213" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S AP: -
           Notes: Unless specified otherwise, all models are assumed to be equipped with a hand
@@ -222,13 +222,13 @@
           it cannot also use a shield.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Great weapon" hidden="false" id="88e3-38f0-92d5-b616" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Great weapon" hidden="false" id="88e3-38f0-92d5-b616" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+2 AP: -2
           Special Rules: Armour Bane (1), Requires Two Hands, Strike Last</characteristic>
       </characteristics>
     </profile>
-    <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Longbow" hidden="false" id="c84c-99b6-75eb-4f40" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="216" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 30&quot; S: 3 AP: -
           Special Rules: Armour Bane (1), Volley Fire</characteristic>
@@ -253,7 +253,7 @@
       </characteristics>
       <comment>#noscript</comment>
     </profile>
-    <profile name="Brace of Repeater Handbows" hidden="false" id="fca0-3c32-72da-53b9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Brace of Repeater Handbows" hidden="false" id="fca0-3c32-72da-53b9" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S3 Multiple Shots
           (4), Quick Shot</characteristic>
@@ -281,13 +281,13 @@
           special rule, use the highest modifier.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Pistol" hidden="false" id="4c62-cdd4-4e0c-4265" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Pistol" hidden="false" id="4c62-cdd4-4e0c-4265" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot; S: 4 AP: -1
           Special Rules: Armour Bane (1), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Brace of Pistols" hidden="false" id="cdb0-f5d2-68e0-205f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Brace of Pistols" hidden="false" id="cdb0-f5d2-68e0-205f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour
           Bane(1), Multiple Shots (2), Quick Shot.
@@ -317,7 +317,7 @@
           than Fall Back in Good Order.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Handgun" hidden="false" id="4035-287b-e117-6b9b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot; S: 4 AP: -1
           Special Rules: Armour Bane (1), Ponderous</characteristic>
@@ -417,19 +417,19 @@
         <characteristic name="Description" typeId="adcd-c649-e6fc-a9f6">+1 Armour Save</characteristic>
       </characteristics>
     </profile>
-    <profile name="Warbow" hidden="false" id="20c1-9325-e604-a558" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Warbow" hidden="false" id="20c1-9325-e604-a558" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Range 24&quot; S S, Volley
           Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Additional Hand Weapon" hidden="false" id="300e-9667-fc8c-c763" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Additional Hand Weapon" hidden="false" id="300e-9667-fc8c-c763" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require
           Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Spear" hidden="false" id="8a6-cc93-b5fd-6636" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Throwing Spear" hidden="false" id="8a6-cc93-b5fd-6636" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S AP: -
           Notes: A throwing spear can only be used during a turn in which the wielder charged. In
@@ -437,7 +437,7 @@
           instead. Special Rules: Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
-    <profile name="Thrusting Spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Thrusting Spear" hidden="false" id="85-9154-7dc1-ddc6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S AP: -
           Notes: Models whose troop type is ‘infantry’ only. A model wielding a thrusting spear
@@ -1159,13 +1159,13 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Bolt Thrower" hidden="false" id="36e4-28b4-31ff-39dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="223" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Bolt Thrower" hidden="false" id="36e4-28b4-31ff-39dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="223" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 48&quot; S: 6 AP: -3
           Special Rules: Cumbersome, Move or Shoot, Multiple Wounds (2), Through &amp; Through</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="226" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Cannon" hidden="false" id="8ef5-8512-e1c2-6474" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="226" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 48&quot; S: 8 AP: -2
           Notes: Cannon (of any type) do not use their crew’s Ballistic Skill. Instead, they shoot
@@ -1174,20 +1174,20 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Stone Thrower" hidden="false" id="3142-ada8-328d-1615" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Stone Thrower" hidden="false" id="3142-ada8-328d-1615" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-60&quot; S4(8) AP-1(-3)
           Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3+1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Organ gun" hidden="false" id="5635-efd8-13b6-c841" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="228" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Organ gun" hidden="false" id="5635-efd8-13b6-c841" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="228" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 30&quot; S: 5 AP: -1
           Notes: This weapon uses the Black Powder Misfire table. Special Rules: Armour Bane (2),
           Cumbersome, Move or Shoot, Multi-Barrelled</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fire Thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="229" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Fire Thrower" hidden="false" id="2694-34f1-f146-6351" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="229" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot; S: 5 AP: -1
           Notes: Fire throwers do not use their crew’s Ballistic Skill. Instead, they shoot using
@@ -1195,13 +1195,13 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           Special Rules: Column of Fire, Cumbersome, Flaming Attacks, Move or Shoot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Javelin" hidden="false" id="f3f8-7476-d165-1a5d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot; S: S AP: -
           Special Rules: Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Cavalry spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Cavalry spear" hidden="false" id="ee75-c1a8-2f0c-c264" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+1 AP: -1
           Notes: Models whose troop type is ‘cavalry’, ‘monster’ or ‘chariot’ only. A cavalry
@@ -1210,33 +1210,33 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           turn in which it charged. Special Rules: Fight in Extra Rank</characteristic>
       </characteristics>
     </profile>
-    <profile name="Morning star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Morning star" hidden="false" id="caad-2fc0-e82a-18fd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+1 AP: -1
           Notes: A morning star’s Strength modifier applies only during the first round of combat.
           Special Rules: -</characteristic>
       </characteristics>
     </profile>
-    <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Halberd" hidden="false" id="98f8-9d8-94cd-3379" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+1 AP: -1
           Special Rules: Armour Bane (1), Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flail" hidden="false" id="b326-5bf3-9b4e-f8ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Flail" hidden="false" id="b326-5bf3-9b4e-f8ad" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+2 AP: -2
           Notes: A flail’s Strength modifier applies only during the first round of combat. Special
           Rules: Requires Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="214" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Whip" hidden="false" id="7505-7edf-c3de-57a6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="214" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S AP: - Special
           Rules: Fight in Extra Rank, Strike First</characteristic>
       </characteristics>
     </profile>
-    <profile name="Lance" hidden="false" id="3520-64c9-a855-ce9e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="215" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Lance" hidden="false" id="3520-64c9-a855-ce9e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="215" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat S: S+2 AP: -2
           Notes: Models whose troop type is ‘cavalry’ or ‘monster’ only. A lance can only be used
@@ -1244,72 +1244,72 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           charge) the model must use its hand weapon instead. Special Rules: Armour Bane (1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="216" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Shortbow" hidden="false" id="1b65-71ef-52a3-93d0" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="216" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 18&quot; S: 3 AP: -
           Special Rules: Quick Shot, Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater Pistol" hidden="false" id="f675-db0d-397c-d873" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Repeater Pistol" hidden="false" id="f675-db0d-397c-d873" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S4 AP-1 Armour Bane
           (1), Multiple Shots (3), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater handgun" hidden="false" id="7f58-91d4-ee6c-3cb7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="217" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Repeater handgun" hidden="false" id="7f58-91d4-ee6c-3cb7" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="217" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot; S: 4 AP: -1
           Special Rules: Armour Bane (1), Multiple Shots (3), Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Crossbow" hidden="false" id="1ef1-8579-c310-4fb5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 30&quot; S: 4 AP: -
           Special Rules: Armour Bane (2), Ponderous</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Repeater crossbow" hidden="false" id="e240-f607-2c57-b181" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 24&quot; S: 3 AP: -
           Special Rules: Armour Bane (1), Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater handbow" hidden="false" id="f187-983f-99f2-5ecd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="218" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Repeater handbow" hidden="false" id="f187-983f-99f2-5ecd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="218" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot; S: 3 AP: -
           Special Rules: Multiple Shots (2), Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Two Hand Weapon" hidden="false" id="1f58-a56f-e54c-ddc5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Two Hand Weapon" hidden="false" id="1f58-a56f-e54c-ddc5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Atacks (+1), Require
           Two Hands</characteristic>
       </characteristics>
     </profile>
-    <profile name="Sling" hidden="false" id="eee6-7b1-58de-6ad2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Sling" hidden="false" id="eee6-7b1-58de-6ad2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 18&quot; S: 3 AP: -
           Special Rules: Multiple Shots (2)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Throwing Axe" hidden="false" id="9914-73b6-65c4-ec44" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 9&quot; S: S+1 AP: -
           Special Rules: Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Throwing Weapon" hidden="false" id="eee5-db12-1271-f2c5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="219" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Throwing Weapon" hidden="false" id="eee5-db12-1271-f2c5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="219" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 9&quot; S: S AP: -
           Special Rules: Multiple Shots (2), Move &amp; Shoot, Quick Shot</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wicked Claws" hidden="false" id="14c0-c7a7-dd09-ea49" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Wicked Claws" hidden="false" id="14c0-c7a7-dd09-ea49" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">AP-2</characteristic>
       </characteristics>
     </profile>
-    <profile name="Serrated Maw" hidden="false" id="2dea-8d5a-633c-cd7d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Serrated Maw" hidden="false" id="2dea-8d5a-633c-cd7d" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Armour Bane(2), Multiple
           Wounds(2)</characteristic>
@@ -1323,7 +1323,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Mortar" hidden="false" id="11c5-c8bc-6ce3-8932" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Mortar" hidden="false" id="11c5-c8bc-6ce3-8932" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12-48&quot; S2(6) AP-2(-3)
           Armour Bane (1), Bombardment, Cumbersome, Move or Shoot, Multiple Wounds (D3)</characteristic>
@@ -1337,7 +1337,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
         <modifier type="set" value="Base" field="name"/>
       </modifiers>
     </profile>
-    <profile name="Flame Cannon" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="5207-3185-698f-a161">
+    <profile name="Flame Cannon" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="5207-3185-698f-a161">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">description of flame cannon</characteristic>
       </characteristics>
@@ -1402,13 +1402,13 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           first.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Repeater Bolt Thrower" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" hidden="false" id="3f5c-8185-3494-86c1">
+    <profile name="Repeater Bolt Thrower" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " hidden="false" id="3f5c-8185-3494-86c1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 48&quot; S: 4 AP: -1
           Special Rules: Armour Bane (1), Cumbersome, Move or Shoot, Multiple Shots(D3+3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Great Cannon" hidden="false" id="ae36-d4c3-eaf5-198b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="226" publicationId="768b-3da1-a182-a1d8">
+    <profile name="Great Cannon" hidden="false" id="ae36-d4c3-eaf5-198b" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="226" publicationId="768b-3da1-a182-a1d8">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 60&quot; S: 10 AP: -3
           Notes: Cannon (of any type) do not use their crew’s Ballistic Skill. Instead, they shoot
@@ -1417,7 +1417,7 @@ Note that models with this special rule are often vulnerable to the Flaming Atta
           (D3=1)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Troll Vomit" hidden="false" id="2007-796b-3c57-ec28" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Troll Vomit" hidden="false" id="2007-796b-3c57-ec28" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S3 AP-2 A Chaos Troll that
           is in base contact with an enemy model may make one additional attack each turn with this

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -39,23 +39,23 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Poisoned Attacks, Strike First. In combat, this model must make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fiend tail" hidden="false" id="46f5-5901-36ed-cabd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="75" publicationId="7c89-736c-3139-24a0">
+    <profile name="Fiend tail" hidden="false" id="46f5-5901-36ed-cabd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="75" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	
 Notes: In combat, a Chimera with a fiend tail may make an additional D3 attacks each turn, each of which must be made with this weapon.	Special Rules: Extra Attacks (D3)</characteristic>
       </characteristics>
     </profile>
-    <profile name="Fumes of Contagion" hidden="false" id="c74a-5987-c842-d1ef" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Fumes of Contagion" hidden="false" id="c74a-5987-c842-d1ef" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S2 Breath Weapon,  Magical Attacks. No armour save is permitted against wounds caused by this weapon (Ward and Regeneration saves can be attempted as normal).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Dark Fire of Chaos" hidden="false" id="bd92-12b9-5474-74a2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="74" publicationId="7c89-736c-3139-24a0">
+    <profile name="Dark Fire of Chaos" hidden="false" id="bd92-12b9-5474-74a2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="74" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 4	AP: -1	Special Rules: Breath Weapon, Flaming Attacks, Magical Attacks</characteristic>
       </characteristics>
     </profile>
-    <profile name="Flaming breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="75" publicationId="7c89-736c-3139-24a0">
+    <profile name="Flaming breath" hidden="false" id="1817-b606-9cde-cd76" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="75" publicationId="7c89-736c-3139-24a0">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 4	AP: -	Special Rules: Breath Weapon, Flaming Attacks</characteristic>
       </characteristics>

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -41,12 +41,12 @@
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">8</characteristic>
       </characteristics>
     </profile>
-    <profile name="Asrai longbow" hidden="false" id="52f0-5d10-bf38-7541" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="147" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Asrai longbow" hidden="false" id="52f0-5d10-bf38-7541" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="147" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 32&quot;	S: S	AP: -	Special Rules: Armour Bane (1), Volley Fire</characteristic>
       </characteristics>
     </profile>
-    <profile name="Enchanted Arrows" hidden="false" id="da29-8223-a95d-8407" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Enchanted Arrows" hidden="false" id="da29-8223-a95d-8407" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9"/>
       </characteristics>
@@ -82,7 +82,7 @@
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A unit with this special rule can make supporting attacks to its flank or rear, as well as to its front</characteristic>
       </characteristics>
     </profile>
-    <profile name="Asrai spear" hidden="false" id="4338-1ef3-1095-9080" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="129" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Asrai spear" hidden="false" id="4338-1ef3-1095-9080" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="129" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	
 Notes: A model wielding an Asrai spear cannot make a supporting attack during a turn in which it charged. During a turn in which it was charged in its front arc, a model wielding an Asrai spear gains a +1 modifier to its Initiative against the charging unit(s).	Special Rules: Fight in Extra Rank</characteristic>
@@ -101,7 +101,7 @@ Notes: A model wielding an Asrai spear cannot make a supporting attack during a 
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Ranger&apos;s Glaive" hidden="false" id="10ef-7481-e2ba-547" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Ranger&apos;s Glaive" hidden="false" id="10ef-7481-e2ba-547" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S+2, AP-2, Requires Two Hands</characteristic>
       </characteristics>
@@ -186,18 +186,18 @@ Note that a Shadowdancer that joins this unit is considered to have this special
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">9</characteristic>
       </characteristics>
     </profile>
-    <profile name="Wicked Claws" hidden="false" id="3e22-4ea4-405d-a8ac" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Wicked Claws" hidden="false" id="3e22-4ea4-405d-a8ac" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S, Ap-2</characteristic>
       </characteristics>
     </profile>
-    <profile name="Serrated Maw" hidden="false" id="76ad-9eb5-36f5-d56e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Serrated Maw" hidden="false" id="76ad-9eb5-36f5-d56e" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">S, Armour Bane (2), Multiple Wounds (2)
 Notes: In combat, this model must make one of its attacks each turn with this weapon.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Soporific breath" hidden="false" id="8d45-3cca-ff3-20f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="138" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Soporific breath" hidden="false" id="8d45-3cca-ff3-20f" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="138" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: N/A	S: 2	AP: N/A	
 Notes: No armour save is permitted against wounds caused by soporific breath (Ward and Regeneration saves can be attempted as normal).	Special Rules: Breath Weapon</characteristic>
@@ -229,12 +229,12 @@ Notes: No armour save is permitted against wounds caused by soporific breath (Wa
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72">-</characteristic>
       </characteristics>
     </profile>
-    <profile name="Oaken fists" hidden="false" id="6130-5aa6-5297-80c2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Oaken fists" hidden="false" id="6130-5aa6-5297-80c2" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="140" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -2	Special Rules: -</characteristic>
       </characteristics>
     </profile>
-    <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="140" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Strangleroots" hidden="false" id="263-5e05-ea8a-23dc" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="140" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: 12&quot;	S: S	AP: -1	Special Rules: Multiple Shots (D6+1)</characteristic>
       </characteristics>
@@ -458,12 +458,12 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Description" typeId="9f84-4221-785a-db50">A Shadowdancer that joins a unit of Wardancers is considered to have the Dances of Loec special rule for as long as they remain with the unit (see page 131).</characteristic>
       </characteristics>
     </profile>
-    <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="122" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Spear of Loec" hidden="false" id="c611-4849-2aad-fb75" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="122" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+1	AP: -1	Special Rules: Armour Bane (2), Killing Blow</characteristic>
       </characteristics>
     </profile>
-    <profile name="Trickater&apos;s Blades" hidden="false" id="205a-ad0c-c943-54f6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Trickater&apos;s Blades" hidden="false" id="205a-ad0c-c943-54f6" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">Extra Attacks (+D3), Require Two Hands</characteristic>
       </characteristics>
@@ -478,7 +478,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Description" typeId="9f84-4221-785a-db50">Impact Hits caused by a model with this special rule have the Armour Bane (1) special rule and an Armour Piercing characteristic of -1.</characteristic>
       </characteristics>
     </profile>
-    <profile name="Mighty antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="126" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Mighty antlers" hidden="false" id="34a4-ebfb-91a-a8dd" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="126" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S	AP: -1	Special Rules: Armour Bane (1)</characteristic>
       </characteristics>
@@ -496,7 +496,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
 - Flock of Doom</characteristic>
       </characteristics>
     </profile>
-    <profile name="Blackbriar Javelines" hidden="false" id="5a44-f24a-a1fa-e3c1" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon">
+    <profile name="Blackbriar Javelines" hidden="false" id="5a44-f24a-a1fa-e3c1" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) ">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">12&quot; S5, AP-1 , Move &amp; Shoot, Quick Shoot</characteristic>
       </characteristics>
@@ -540,7 +540,7 @@ However, if the Arrow of Kurnous is fired, your opponent adds +1 to their roll w
         <characteristic name="Ld" typeId="c435-6b14-f77e-3c72"/>
       </characteristics>
     </profile>
-    <profile name="Hunting spear" hidden="false" id="5df6-55ba-e648-e1b5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon" page="136" publicationId="8b8d-8fc4-559e-87b1">
+    <profile name="Hunting spear" hidden="false" id="5df6-55ba-e648-e1b5" typeId="cc88-6a7d-41c9-d63e" typeName="Weapon (free-text) " page="136" publicationId="8b8d-8fc4-559e-87b1">
       <characteristics>
         <characteristic name="Description" typeId="47f2-ecee-cae0-9ef9">R: Combat	S: S+1	AP: -2	
 Notes: A hunting spear can only be used during a turn in which the wielder charged. In subsequent turns (or if the wielder did not charge) the model must use its hand weapon instead.	Special Rules: Armour Bane (1)</characteristic>


### PR DESCRIPTION
You may want to go through and check weapon names, which I've forced to titlecase, and change them back if you don't want that.

This also returns all the special rules to non-column format.