### PR TITLE
Fix typo for Ogre kingdom from "Grionbiter" to "Groinbiter"

### DIFF
--- a/Ogre Kingdoms.cat
+++ b/Ogre Kingdoms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="60" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorName="Flammy" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="61" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorName="Flammy" authorUrl="www.newrecruit.eu">
   <sharedProfiles>
     <profile name="Tyrant" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="f58e-2d63-3721-5926">
       <characteristics>
@@ -2936,7 +2936,7 @@ Enemy models removed from play are considered to have been removed from the figh
                 <infoLink name="Gnoblar Fighter" hidden="false" type="profile" id="ad587312-b943125c" targetId="fd69-de7b-abf2-c35d">
                   <modifiers>
                     <modifier type="increment" value="1" field="dddc-9fbd-b0fd-a480"/>
-                    <modifier type="set" value="Grionbiter" field="name"/>
+                    <modifier type="set" value="Groinbiter" field="name"/>
                   </modifiers>
                 </infoLink>
                 <infoLink name="Champion" hidden="false" type="profile" id="653283f0-f937c3ba" targetId="5f1c-fd04-b0d5-d5e"/>


### PR DESCRIPTION
This is related to https://github.com/vflam/Warhammer-The-Old-World/issues/367. Not tested but im confident this wont break anything. If you want me to test let me know. 

Cheers