### PR TITLE
Fix Dance of Death special rule to only include the special rule.

### DIFF
--- a/Dark Elves.cat
+++ b/Dark Elves.cat
@@ -699,7 +699,7 @@ If a unit in which a Khainite Assassin is hiding is destroyed or flees the battl
     </profile>
     <profile name="Dance Of Death" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="410d-4b9e-8e83-6ff3">
       <characteristics>
-        <characteristic name="Description" typeId="9f84-4221-785a-db50">Sisters of Slaughter weave through the enemy’s defences, plunging deep into their ranks. If this unit makes a successful charge move (i.e., if the unit makes contact with the charge target), the charge target suffers a -1 modifier to its Maximum Rank Bonus until the end of the Combat phase of that turn.</characteristic>
+        <characteristic name="Description" typeId="9f84-4221-785a-db50">If this unit makes a successful charge move (i.e., if the unit makes contact with the charge target), the charge target suffers a -1 modifier to its Maximum Rank Bonus until the end of the Combat phase of that turn.</characteristic>
       </characteristics>
     </profile>
     <profile name="Cursed Coven" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule" hidden="false" id="de9b-915c-95a0-803e">


### PR DESCRIPTION
Looks like Flavor text plus sisters of slaughter Weapon profile sneaked into the Dance of death special rule. Here is the section in the rules:

<img width="544" height="217" alt="image" src="https://github.com/user-attachments/assets/2028aa64-8474-4497-a7e9-d736b01e8100" />

This Pull request removes the Flavor text and profile, leaving only the Dance of Death special rule in the special rule.