### PR TITLE
fix: Ogre Kingdoms Giant did not update Toughness

### DIFF
--- a/Ogre Kingdoms.cat
+++ b/Ogre Kingdoms.cat
@@ -351,7 +351,7 @@
         <characteristic name="WS" typeId="b007-7d58-4f14-1e01">3</characteristic>
         <characteristic name="BS" typeId="59f9-ccf5-1155-fb05">1</characteristic>
         <characteristic name="S" typeId="5b6b-1427-2a45-dd0c">6</characteristic>
-        <characteristic name="T" typeId="ab43-8b61-83e7-d090">6</characteristic>
+        <characteristic name="T" typeId="ab43-8b61-83e7-d090">7</characteristic>
         <characteristic name="W" typeId="83ed-7b82-bf1f-e558">6</characteristic>
         <characteristic name="I" typeId="73b1-abe5-72f8-41e2">2</characteristic>
         <characteristic name="A" typeId="dddc-9fbd-b0fd-a480">*</characteristic>

--- a/Ogre Kingdoms.cat
+++ b/Ogre Kingdoms.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="72" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorName="Flammy" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="13ed-b3e5-e610-615f" name="Ogre Kingdoms" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="49" revision="73" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorName="Flammy" authorUrl="www.newrecruit.eu">
   <sharedProfiles>
     <profile name="Tyrant" typeId="b070-143a-73f-2772" typeName="Model" hidden="false" id="f58e-2d63-3721-5926">
       <characteristics>


### PR DESCRIPTION
With https://assets.warhammer-community.com/eng_07-07_whtow_ravening_hordes_faq-gnovl32nnu-vqyzrqk2p1.pdf the Chaos giants Toughness was increased by one (from 6 to 7). 
This was already corrected for Beastmen, Warriors of Chaos and Orcs & Goblin tribes, but not for the legacy faction Ogre Kingdoms.
This commit will align the Giants over all factions

fixes https://github.com/vflam/Warhammer-The-Old-World/issues/649