### PR TITLE
fix: Marauder Horsemen have no access to Marks of Chaos

### DIFF
--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c908-5f26-5bdf-2a48" name="Warriors of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="114" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c908-5f26-5bdf-2a48" name="Warriors of Chaos" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="22" revision="115" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue">
   <sharedProfiles>
     <profile name="Chaos Armour" hidden="false" id="5073-af52-fe26-36ff" typeId="c1ac-c1c8-f9d5-9673" typeName="Special Rule">
       <characteristics>
@@ -3957,35 +3957,6 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dc6e-4230-4797-37c5"/>
               </constraints>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Mark of Chaos" hidden="false" id="8f21-0c2a-9d3b-0001" defaultSelectionEntryId="8f21-0c2a-9d3b-0004" sortIndex="5">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8f21-0c2a-9d3b-0002"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f21-0c2a-9d3b-0003"/>
-              </constraints>
-              <entryLinks>
-                <entryLink import="true" name="Mark of Chaos Undivided" hidden="false" type="selectionEntry" id="8f21-0c2a-9d3b-0004" targetId="ad1d-818d-48e-9457" sortIndex="1"/>
-                <entryLink import="true" name="Mark of Khorne" hidden="false" type="selectionEntry" id="8f21-0c2a-9d3b-0005" targetId="dbfd-c8b3-5688-4550" sortIndex="2">
-                  <costs>
-                    <cost name="pts" typeId="points" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Mark of Nurgle" hidden="false" type="selectionEntry" id="8f21-0c2a-9d3b-0006" targetId="f69c-c9ca-68f1-eebf" sortIndex="3">
-                  <costs>
-                    <cost name="pts" typeId="points" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Mark of Slaanesh" hidden="false" type="selectionEntry" id="8f21-0c2a-9d3b-0007" targetId="3a04-dd84-1ba5-187c" sortIndex="4">
-                  <costs>
-                    <cost name="pts" typeId="points" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Mark of Tzeentch" hidden="false" type="selectionEntry" id="8f21-0c2a-9d3b-0008" targetId="5769-43d9-7b87-ed75" sortIndex="5">
-                  <costs>
-                    <cost name="pts" typeId="points" value="2"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <infoLinks>


### PR DESCRIPTION
With https://assets.warhammer-community.com/eng_07-07_whtow_ravening_hordes_faq-gnovl32nnu-vqyzrqk2p1.pdf the Chaos Marauder Horsemen have gotten an updated unit sheet (page 9). There is no mentioning of the Marks of Chaos at all but only the Special rule "Mark of Chaos Undivided" 
Hence, the Marks of Chaos selection should not be available.

This commit removes the Marks of Chaos from the Marauder Horsemen entry. 

fixes #643