### PR TITLE
fix: Squig Herds Impetuous rule remove modifier

### DIFF
--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="185" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="186" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Orc Mobs" hidden="false" id="51e8-1471-ce4c-d5dd">
       <profiles>
@@ -5542,11 +5542,7 @@
                     <modifier type="append" value="(Dwarfs)" field="name"/>
                   </modifiers>
                 </infoLink>
-                <infoLink name="Impetuous" hidden="false" type="profile" id="c8e8-eae8-546f-eb43" targetId="b664-8530-a988-7ba9">
-                  <modifiers>
-                    <modifier type="append" value="(-2)" field="name"/>
-                  </modifiers>
-                </infoLink>
+                <infoLink name="Impetuous" hidden="false" type="profile" id="c8e8-eae8-546f-eb43" targetId="b664-8530-a988-7ba9"/>
                 <infoLink name="Open Order" hidden="false" type="profile" id="42cf-1b40-f6af-4785" targetId="5b67-8535-146c-7cea"/>
                 <infoLink name="Immune To Psychology" hidden="false" type="profile" id="b622-92da-c08-6a" targetId="93d9-c75b-f655-30ac"/>
                 <infoLink name="Loner" hidden="false" type="profile" id="aba5-8197-343d-cc5d" targetId="2ecd-c6b3-bd8b-864b"/>


### PR DESCRIPTION
the Night Goblin Squig Herds "Impetuous" rule has a -2 modifier. This seems to be an error as I cannot find that modifier anywhere.

Hence removing it.

fixes #633