### PR TITLE
fix: Troll Horde battle march core trolls

### DIFF
--- a/Orc and Goblin Tribes - Troll Horde.cat
+++ b/Orc and Goblin Tribes - Troll Horde.cat
@@ -1782,17 +1782,20 @@
             <repeat value="2.857142857142857" repeats="1" field="points" scope="force" childId="any" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
-        <modifier type="floor" value="1" field="0c0a-c4bc-659a-f54a">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="0c0a-c4bc-659a-f54a">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
         </modifier>
-        <modifier type="floor" value="1" field="f09f-3788-b242-f5aa">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="f09f-3788-b242-f5aa">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
+        </modifier>
+        <modifier type="floor" value="0" field="0c0a-c4bc-659a-f54a">
+          <comment>Battle march: -1 would mean unlimited</comment>
         </modifier>
       </modifiers>
     </entryLink>
@@ -2006,17 +2009,20 @@
             <repeat value="2.857142857142857" repeats="1" field="points" scope="force" childId="any" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
-        <modifier type="floor" value="1" field="6a53-7719-7122-6a7e">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="6a53-7719-7122-6a7e">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
         </modifier>
-        <modifier type="floor" value="1" field="48cc-835b-8afe-1f54">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="48cc-835b-8afe-1f54">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
+        </modifier>
+        <modifier type="floor" value="0" field="6a53-7719-7122-6a7e">
+          <comment>Battle march: -1 would mean unlimited</comment>
         </modifier>
       </modifiers>
     </entryLink>
@@ -2232,17 +2238,20 @@
             <repeat value="2.857142857142857" repeats="1" field="points" scope="force" childId="any" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
-        <modifier type="floor" value="1" field="103e-ac76-427f-51da">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="103e-ac76-427f-51da">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
         </modifier>
-        <modifier type="floor" value="1" field="4aab-3389-7149-77ee">
-          <comment>Battle march</comment>
+        <modifier type="increment" value="1" field="4aab-3389-7149-77ee">
+          <comment>Battle march: cross reference other trolls. If one is available increase count by 1</comment>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
           </conditions>
+        </modifier>
+        <modifier type="floor" value="0" field="103e-ac76-427f-51da">
+          <comment>Battle march: -1 would mean unlimited</comment>
         </modifier>
       </modifiers>
     </entryLink>


### PR DESCRIPTION
In the Troll Horde catalog, each Core troll mob entry (Common/Stone/River) implements "one troll mob of any type per 1000 pts" via a per-entry min/max constraint that is incremented +1 per 1000 pts and decremented -1 for each selection of the other two troll mob links (<comment>other core trolls</comment>).

For Battle March (force e40a-36c4-0c66-472a), the min/max were adjusted with <modifier type="floor" value="1">. A floor clamps the final value back up to 1 after the "other core trolls" decrement, so selecting e.g. a Stone Troll Mob no longer reduced the min of Common/River back to 0 — the app demanded one of each mob instead of one of any.

Two changes:

- The six floor value="1" modifiers (min+max on the three Core troll mob links) become increment value="1" with the same Battle March condition. Increments combine additive with the existing decrements, so in Battle March each mob's min/max = 1 − (other troll mobs selected), reproducing the normal-game "one of any" behavior (and preserving the Troll Hag +1 max bonus).

- A floor value="0" modifier is appended to each mob's max constraint: with all three mobs selected the max would compute to 1 − 2 = −1, which newRecruit interprets as unlimited, silently disabling the max validation. Clamping at 0 makes the "too many selections" error appear correctly.

fixes #681