### PR TITLE
fix: Glade Riders unit size label

### DIFF
--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -3936,7 +3936,7 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
         <profile name="Glade Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3512-3d63-ebce-3810">
           <characteristics>
             <characteristic name="Troop Type" typeId="5d94-6b94-bd89-1944">Light cavalry</characteristic>
-            <characteristic name="Unit Size" typeId="80a1-bb6f-66e4-4a5b">5+</characteristic>
+            <characteristic name="Unit Size" typeId="80a1-bb6f-66e4-4a5b">4+</characteristic>
           </characteristics>
         </profile>
       </profiles>


### PR DESCRIPTION
The minimal amount of Glade Riders was already changed from 5 to 4, but the label we show in the print/detail version was still 5+ Fix is trivial.

Fixing #658