### PR TITLE
Battle March: enforce maximum unit strength 20 via troop-type model caps

### DIFF
--- a/Beastmen Brayherds.cat
+++ b/Beastmen Brayherds.cat
@@ -2140,6 +2140,9 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Bestigor Herds" hidden="false" id="b79c-3a34-d2a3-df2b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="23e8-8b0a-5dc4-acab"/>
+      </constraints>
       <profiles>
         <profile name="Bestigor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7eb-c00d-2d7e-a178">
           <characteristics>
@@ -2314,9 +2317,26 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="84b3-138e-7ea5-b8b7" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="23e8-8b0a-5dc4-acab">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gor Herds" hidden="false" id="934e-f364-eda1-715c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="db12-26ea-0273-62e8"/>
+      </constraints>
       <profiles>
         <profile name="Gor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="fb9-a2b6-46b-3ce2">
           <characteristics>
@@ -2601,9 +2621,26 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="9bee-8abc-214b-fe7c" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="db12-26ea-0273-62e8">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ungor Herds" hidden="false" id="55ac-3093-dbc4-5b4d">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8ea7-a34a-30b1-1a75"/>
+      </constraints>
       <profiles>
         <profile name="Ungor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="747a-880-5ac2-d605">
           <characteristics>
@@ -2811,9 +2848,42 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="a892-5f39-6fa3-3c57" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="8ea7-a34a-30b1-1a75">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Harpies" hidden="false" id="de54-b440-ee4f-246">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b18f-7345-500e-ecb9"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b18f-7345-500e-ecb9">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Harpy" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5ac1-dc76-e57e-cbf7">
           <characteristics>
@@ -2866,6 +2936,25 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Minotaur Herds" hidden="false" id="a60-a56e-1b19-1969">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8256-5870-2e96-e2c5"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8256-5870-2e96-e2c5">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Minotaur Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="74c3-94f8-1297-5888">
           <characteristics>
@@ -3083,6 +3172,25 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Centigor Herds" hidden="false" id="43aa-997b-b101-b0b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="340d-fedb-9fcf-474a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="340d-fedb-9fcf-474a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Centigor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="baea-cae4-2812-243c">
           <characteristics>
@@ -3349,6 +3457,25 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Warhounds" hidden="false" id="22da-f2b2-cf5a-f8e7">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f1ad-da48-ac5f-136e"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f1ad-da48-ac5f-136e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Warhounds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3083-e7ff-b73b-e369">
           <characteristics>
@@ -3453,6 +3580,25 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Razorgor Herds" hidden="false" id="acf6-61aa-8985-987b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0b21-4626-89b5-9330"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0b21-4626-89b5-9330">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Razorgor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="8b18-4f30-13f3-9900">
           <characteristics>
@@ -4504,6 +4650,9 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Warped Gors" hidden="false" id="c510-e701-996f-938c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e300-3027-b7d5-96a5"/>
+      </constraints>
       <profiles>
         <profile name="Warped Gors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4359-88f9-d811-ead7">
           <characteristics>
@@ -4657,9 +4806,56 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
             <condition type="atLeast" value="1" field="selections" scope="self" childId="c99b-c733-4714-36f6" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="e300-3027-b7d5-96a5">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Primal Warhounds" hidden="false" id="95cf-6343-24ef-8715">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b11b-912c-bc34-e8df"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b11b-912c-bc34-e8df">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="b11b-912c-bc34-e8df">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Primal Warhounds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="8a38-f318-d203-e143">
           <characteristics>
@@ -4789,6 +4985,25 @@ Alternatively, if the Herdstone is replacing a special feature specified by a sc
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Primal Warherds" hidden="false" id="9179-2394-9c54-118b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b2d7-63b6-0524-e974"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b2d7-63b6-0524-e974">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Gor Herds" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b24d-5371-1897-f834">
           <characteristics>

--- a/Bretonnians.cat
+++ b/Bretonnians.cat
@@ -950,6 +950,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1ca3-3f32-d359-3e69"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1ca3-3f32-d359-3e69">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="f348-7c13-b712-a3e1" name="Grail Knight" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -2454,6 +2473,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Knights of the Realm on Foot" hidden="false" id="a70a-7cbc-f4ac-ebd8">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b8ca-0255-923d-cb9c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b8ca-0255-923d-cb9c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Knight of the Realm" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a3ee-78da-6b19-5fe3">
           <characteristics>
@@ -2672,6 +2710,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Squires" hidden="false" id="fe35-2f6a-54fe-68a0">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c57e-fb32-de83-ecd3"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c57e-fb32-de83-ecd3">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Squires" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3ad5-2d80-48c7-6aa9">
           <characteristics>
@@ -2809,6 +2866,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Men-At-Arms" hidden="false" id="7070-3759-d579-6b24">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6fbd-7a54-0e64-b749"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6fbd-7a54-0e64-b749">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Men-At-Arms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="ffc1-3a0d-1581-84dc">
           <characteristics>
@@ -2979,6 +3055,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Peasant Bowmen" hidden="false" id="5e10-1040-5760-5ed2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7d1a-e011-2519-225f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7d1a-e011-2519-225f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Peasant Bowman" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="cdcd-b96a-dd18-d05e">
           <characteristics>
@@ -3155,6 +3250,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Battle Pilgrims &amp; Grail Reliquae" hidden="false" id="573b-ddad-d3fe-b920">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d265-d4a4-9dec-645a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="d265-d4a4-9dec-645a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Battle Pilgrim &amp; Grail Reliquae" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3588-20f2-7b25-417f">
           <characteristics>
@@ -3280,6 +3394,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="3fd5-7cc7-a99e-be97"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="3fd5-7cc7-a99e-be97">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="7dd9-2ca4-a616-29e4" name="Knight Errant" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -3516,6 +3649,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9ed2-d87c-e2ed-bdd1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="9ed2-d87c-e2ed-bdd1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="54ce-96e7-b7e1-3b4b" name="Mounted Knight of the Realm" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -3750,6 +3902,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="79f6-c530-b7f1-71e9"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="79f6-c530-b7f1-71e9">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="8e6a-8024-7f80-4cdd" name="Questing Knights" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -4158,6 +4329,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="ab6b-5e0d-a245-468a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="ab6b-5e0d-a245-468a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="378f-29d-54c1-22fb" name="Mounted Yeomen" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -4658,6 +4848,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Border Princes Brigands" hidden="false" id="a812242e-b7308d38" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="ffa2-42b9-8a71-36da"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="ffa2-42b9-8a71-36da">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Border Princes Brigands" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="333f-19fa-d3e4-3492">
           <characteristics>
@@ -5260,6 +5469,25 @@ A unit with this Chivalrous Vow cannot be joined by a character with the Peasant
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Yeomen Guard" hidden="false" id="eef6-a719-3c0a-ef00" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="a8f8-d447-d613-80dd"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="a8f8-d447-d613-80dd">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Yeomen Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2cd1553c-ed9477c6">
           <characteristics>

--- a/Chaos Dwarfs - Renegades 2.0.cat
+++ b/Chaos Dwarfs - Renegades 2.0.cat
@@ -1768,6 +1768,25 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Infernal Ironsworn" hidden="false" id="e1587e88-e4db0932" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f85f-cb79-2129-0ecb"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f85f-cb79-2129-0ecb">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Infernal Ironsworn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="87f0638e-c1b2e798">
           <characteristics>
@@ -1950,6 +1969,9 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Infernal Guard" hidden="false" id="f61860f4-34e371fe" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="3756-021e-90f1-72bf"/>
+      </constraints>
       <profiles>
         <profile name="Infernal Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b74329d2-82a2131c">
           <characteristics>
@@ -2181,9 +2203,42 @@ Note that this special rule is not cumulative. In other words, using it more tha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="f947-b49f-cebe-f3fc" shared="true" includeChildSelections="true" childName="Veteran"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="3756-021e-90f1-72bf">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="K’daai Fireborn" hidden="false" id="49576b8c-26b4cbd6" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="12fd-1d56-06bf-dd3a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="12fd-1d56-06bf-dd3a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="K’daai Fireborn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2c631caa-f10d0f54">
           <characteristics>
@@ -2299,6 +2354,25 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hobgoblin Cutthroats" hidden="false" id="1dcb4a75-35fdf76b" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b6b3-4a86-a7a1-0885"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b6b3-4a86-a7a1-0885">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Hobgoblin Cutthroats" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3b0ec193-1f02ec41">
           <characteristics>
@@ -2425,6 +2499,25 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sneaky Gits" hidden="false" id="c6225928-49d10ed2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="188f-462d-1f7c-35b2"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="188f-462d-1f7c-35b2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Sneaky Gits" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b3f8722e-65746b38">
           <characteristics>
@@ -2522,6 +2615,9 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hobgoblin Wolf Riders" hidden="false" id="a6507dd1-a0a8a527" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="22e0-a2e5-6ea8-7aac"/>
+      </constraints>
       <profiles>
         <profile name="Hobgoblin Wolf Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="342f7937-97d2f005">
           <characteristics>
@@ -2715,6 +2811,20 @@ Note that this special rule is not cumulative. In other words, using it more tha
         <modifier type="add" value="5c4d-3c7a-3d15-1793" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="d177986a-5c1fad14" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="22e0-a2e5-6ea8-7aac">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3644,6 +3754,9 @@ Note that this special rule is not cumulative. In other words, using it more tha
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Dwarf Warriors" hidden="false" id="7057-6141-43c9-d9e3">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0947-d515-5538-d723"/>
+      </constraints>
       <categoryLinks>
         <categoryLink name="Faction: Chaos Dwarfs" hidden="false" id="4731-294e-b49d-9325" targetId="a37d-c797-76ec-1c53" primary="false"/>
         <categoryLink name="Regimental Unit" hidden="false" id="285a-dba5-9c49-25ec" targetId="5e89-9cfa-f74-43ea" primary="false"/>
@@ -3860,9 +3973,26 @@ Note that this special rule is not cumulative. In other words, using it more tha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="d8ca-2f83-673c-3f5b" shared="true" includeChildSelections="true" childName="Veteran"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="0947-d515-5538-d723">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Blunderbuss Decimators" hidden="false" id="37ad-5022-3124-c3d1">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0458-1f5d-c481-ce48"/>
+      </constraints>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Blunderbuss Decimators" hidden="false" id="c7df-dfdb-0250-ac58">
           <infoLinks>
@@ -4026,6 +4156,20 @@ Note that this special rule is not cumulative. In other words, using it more tha
         <modifier type="add" value="ec97-f5da-0a3e-c7cb" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="b423-5f53-f71a-7291" shared="true" includeChildSelections="true" childName="Drilled"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="0458-1f5d-c481-ce48">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Chaos Dwarfs - Renegades 2.0.cat
+++ b/Chaos Dwarfs - Renegades 2.0.cat
@@ -8835,11 +8835,6 @@ Note that this special rule is not cumulative. In other words, using it more tha
                 </infoGroup>
               </infoGroups>
               <entryLinks>
-                <entryLink import="true" name="Mace Tail" hidden="false" id="58bb-f1a1-8b1b-d337" type="selectionEntry" targetId="b9421430-a5c8d1fa">
-                  <costs>
-                    <cost name="pts" typeId="points" value="10"/>
-                  </costs>
-                </entryLink>
                 <entryLink import="true" name="Sorcerous Exhalation" hidden="false" id="2064-aeaf-6f52-3cd8" type="selectionEntry" targetId="c29907e6-e4f6fef0">
                   <costs>
                     <cost name="pts" typeId="points" value="15"/>

--- a/Chaos Dwarfs.cat
+++ b/Chaos Dwarfs.cat
@@ -1745,6 +1745,25 @@ When rolling To Wound, the target number is the same as the armour value of the
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Infernal Ironsworn" hidden="false" id="e1587e88-e4db0932" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="fd54-f892-0ef6-eb2a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="fd54-f892-0ef6-eb2a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Infernal Ironsworn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="87f0638e-c1b2e798">
           <characteristics>
@@ -1922,6 +1941,9 @@ When rolling To Wound, the target number is the same as the armour value of the
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Infernal Guard" hidden="false" id="f61860f4-34e371fe" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2d9e-17ed-f8aa-fdd2"/>
+      </constraints>
       <profiles>
         <profile name="Infernal Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b74329d2-82a2131c">
           <characteristics>
@@ -2154,9 +2176,42 @@ When rolling To Wound, the target number is the same as the armour value of the
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="a7b30e65-c19e35b" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="2d9e-17ed-f8aa-fdd2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="K’daai Fireborn" hidden="false" id="49576b8c-26b4cbd6" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="4f93-8eb4-0722-08fc"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="4f93-8eb4-0722-08fc">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="K’daai Fireborn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2c631caa-f10d0f54">
           <characteristics>
@@ -2279,6 +2334,25 @@ When rolling To Wound, the target number is the same as the armour value of the
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hobgoblin Cutthroats" hidden="false" id="1dcb4a75-35fdf76b" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0a35-5def-b75e-ce11"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0a35-5def-b75e-ce11">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Hobgoblin Cutthroats" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3b0ec193-1f02ec41">
           <characteristics>
@@ -2405,6 +2479,25 @@ When rolling To Wound, the target number is the same as the armour value of the
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sneaky Gits" hidden="false" id="c6225928-49d10ed2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6a72-e800-7251-063b"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6a72-e800-7251-063b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Sneaky Gits" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b3f8722e-65746b38">
           <characteristics>
@@ -2502,6 +2595,9 @@ When rolling To Wound, the target number is the same as the armour value of the
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hobgoblin Wolf Riders" hidden="false" id="a6507dd1-a0a8a527" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e3db-28a6-c81d-d063"/>
+      </constraints>
       <profiles>
         <profile name="Hobgoblin Wolf Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="342f7937-97d2f005">
           <characteristics>
@@ -2695,6 +2791,20 @@ When rolling To Wound, the target number is the same as the armour value of the
         <modifier type="add" value="5c4d-3c7a-3d15-1793" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="d177986a-5c1fad14" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="e3db-28a6-c81d-d063">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Chaos Library.cat
+++ b/Chaos Library.cat
@@ -92,6 +92,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Ogres" hidden="false" id="d7c9-d-55d4-9c7f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="da84-b9f5-6083-c398"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="da84-b9f5-6083-c398">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Ogres" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="cd6-b48c-32e6-f08b">
           <characteristics>
@@ -548,6 +567,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Trolls" hidden="false" id="df02-abd1-c7f7-4233">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="ffc6-f947-cd60-61ac"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="ffc6-f947-cd60-61ac">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Troll" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d52b-85f9-60e-c9f8">
           <characteristics>

--- a/Daemons of Chaos.cat
+++ b/Daemons of Chaos.cat
@@ -1825,6 +1825,25 @@ Heavy infantry (character)        </profile>
       <comment>Character Mount</comment>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Bloodletters Of Khorne" hidden="false" id="b1564921-d8699af7" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="07a0-7a5e-3ee1-e5a2"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="07a0-7a5e-3ee1-e5a2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Bloodletters Of Khorne" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="74b8aac7-fb462d15">
           <characteristics>
@@ -1954,6 +1973,9 @@ Heavy infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Flesh Hounds Of Khorne" hidden="false" id="daf0d29-e46c07ff" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c778-0b12-008f-9f8e"/>
+      </constraints>
       <profiles>
         <profile name="Flesh Hounds Of Khorne" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="51ff75af-c8bc06bd">
           <characteristics>
@@ -2062,6 +2084,20 @@ Heavy infantry (character)        </profile>
         <modifier type="add" value="23b0-980c-fe27-93ab" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="1c76-b9e0-c5ab-c630" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="c778-0b12-008f-9f8e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2711,6 +2747,25 @@ Regular infantry (character)        </profile>
       </modifierGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Plaguebearers Of Nurgle" hidden="false" id="47fcba1a-5b6e0a04" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="bcec-0a69-e76e-2180"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="bcec-0a69-e76e-2180">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Plaguebearers Of Nurgle" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a1bf8400-32c8c94a">
           <characteristics>
@@ -2831,6 +2886,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Beasts Of Nurgle" hidden="false" id="53aef174-7c417e7e" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1848-342a-d2ef-8c84"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1848-342a-d2ef-8c84">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Beasts Of Nurgle" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e7cb4a52-d8e52f9c">
           <characteristics>
@@ -2901,6 +2975,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Nurglings" hidden="false" id="96b828e9-2ece45bf" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="aa8a-a34f-feb7-d075"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="aa8a-a34f-feb7-d075">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Nurglings" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2bbd70ef-4c3027fd">
           <characteristics>
@@ -3519,6 +3612,25 @@ Regular infantry (character)        </profile>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Daemonettes Of Slaanesh" hidden="false" id="a2c63511-9b36a267" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d56b-f798-248c-4014"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="d56b-f798-248c-4014">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Daemonettes Of Slaanesh" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="edadc5f7-5b78d6c5">
           <characteristics>
@@ -3633,6 +3745,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Seekers Of Slaanesh" hidden="false" id="d9b356b8-38b02ca2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="debf-5df0-6659-e869"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="debf-5df0-6659-e869">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Seekers Of Slaanesh" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="25ad143e-e7360988">
           <characteristics>
@@ -3842,6 +3973,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hellflayer Of Slaanesh" hidden="false" id="6b44b276-2609940" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="03d3-beda-f306-8e26"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="03d3-beda-f306-8e26">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink name="Daemon of Slaanesh" hidden="false" id="61c4-6e0e-832c-4174" targetId="2955-25dc-92ce-6e4a" primary="false"/>
         <categoryLink name="Faction: Daemons of Chaos" hidden="false" id="c529-405e-6a68-3c03" primary="false" targetId="1f7f-18ff-388d-f1f3"/>
@@ -4287,6 +4437,25 @@ Regular infantry (character)        </profile>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Pink Horrors Of Tzeentch" hidden="false" id="c04b2a23-8ff80651" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1aa0-9d71-ecc5-5a0e"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1aa0-9d71-ecc5-5a0e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Pink Horrors Of Tzeentch" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="bf755311-6d7cd067">
           <characteristics>
@@ -4406,6 +4575,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Blue Horrors Of Tzeentch" hidden="false" id="71a2a427-36037bf5" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="855c-6dd7-ba68-8367"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="855c-6dd7-ba68-8367">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Blue Horrors Of Tzeentch" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4118393d-1464ca73">
           <characteristics>
@@ -4679,6 +4867,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Brimstone Horrors Of Tzeentch" hidden="false" id="ebb5370-c4fe173a" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="64d4-fe13-f4eb-662f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="64d4-fe13-f4eb-662f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Brimstone Horrors Of Tzeentch" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6a880016-e72dbae0">
           <characteristics>
@@ -4729,6 +4936,25 @@ Regular infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Screamers Of Tzeentch" hidden="false" id="747803a7-8c31df75" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="447d-4775-2d33-617d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="447d-4775-2d33-617d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Screamers Of Tzeentch" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7c8a08bd-9acc1df3">
           <characteristics>
@@ -5333,6 +5559,9 @@ Monstrous infantry (character)        </profile>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Furies" hidden="false" id="3c1cf41a-28bc7404" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c7a1-7299-e5a8-3300"/>
+      </constraints>
       <profiles>
         <profile name="Chaos Furies" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="96cfe00-ed3a734a">
           <characteristics>
@@ -5470,6 +5699,20 @@ Monstrous infantry (character)        </profile>
           <comment>for Herald per unit with same Alignment</comment>
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="self" childId="e20-3c11-13b5-e880" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="c7a1-7299-e5a8-3300">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Dark Elves.cat
+++ b/Dark Elves.cat
@@ -2252,6 +2252,9 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dark Elf Warriors" hidden="false" id="d975f8f-a6d3a01d" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7ced-0d02-988d-a56c"/>
+      </constraints>
       <profiles>
         <profile name="Dark Elf Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="88471cc5-8ba4edbb">
           <characteristics>
@@ -2429,9 +2432,42 @@ Note that this special rule does not apply to this model’s mount (should it ha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="800b-176c-303b-2015" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="7ced-0d02-988d-a56c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Black Ark Corsairs" hidden="false" id="52540cc9-acb2e49f" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2521-4110-e612-fa49"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2521-4110-e612-fa49">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Black Ark Corsairs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b572c8cf-9009bf5d">
           <characteristics>
@@ -2579,6 +2615,25 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Black Guard Of Naggarond" hidden="false" id="ce5cff9e-8bd79668" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d0ce-646d-50f7-2609"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="d0ce-646d-50f7-2609">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Black Guard Of Naggarond" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="fc8b66c-eef713b6">
           <characteristics>
@@ -2726,6 +2781,25 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Har Ganeth Executioners" hidden="false" id="3436f1de-54cff6a8" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0ad1-5133-74ee-4c6a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0ad1-5133-74ee-4c6a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Har Ganeth Executioners" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="24b5b12c-31263876">
           <characteristics>
@@ -2876,6 +2950,9 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dark Elf Shades" hidden="false" id="2b25ccf3-d6f586a1" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e3b6-328d-f418-6983"/>
+      </constraints>
       <profiles>
         <profile name="Dark Elf Shades" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="8d9dcae1-2ce70eb7">
           <characteristics>
@@ -3052,9 +3129,42 @@ Note that this special rule does not apply to this model’s mount (should it ha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="4d40e55a-9cb6db44" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="e3b6-328d-f418-6983">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Witch Elves" hidden="false" id="564f661a-29cb5604" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8685-aea6-1097-15a0"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8685-aea6-1097-15a0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Witch Elves" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="543bb000-3803954a">
           <characteristics>
@@ -3197,6 +3307,25 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Harpies" hidden="false" id="6b4eb658-dbde75c2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7b3a-5065-afba-44de"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7b3a-5065-afba-44de">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Harpies" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="1966705e-138f8128">
           <characteristics>
@@ -3250,6 +3379,25 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Cold One Knights" hidden="false" id="ad37437a-3b7a8064" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b746-9d52-691d-b5d4"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b746-9d52-691d-b5d4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Cold One Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6f9d89e0-561ce4aa">
           <characteristics>
@@ -3449,6 +3597,9 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dark Riders" hidden="false" id="4fc633f7-dd5dd4c5" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c42e-db3f-0bd8-3404"/>
+      </constraints>
       <profiles>
         <profile name="Dark Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="65a623cd-70c7a03">
           <characteristics>
@@ -3650,9 +3801,42 @@ Note that this special rule does not apply to this model’s mount (should it ha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="f539274c-782aa996" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="c42e-db3f-0bd8-3404">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Doomfire Warlocks" hidden="false" id="879a782b-41817279" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="4186-de3e-6999-297a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="4186-de3e-6999-297a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Doomfire Warlocks" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="67b031d9-c789582f">
           <characteristics>
@@ -4296,6 +4480,9 @@ Note that this special rule does not apply to this model’s mount (should it ha
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dark Elf Crossbowmen" hidden="false" id="5fd8-d99b-5288-8da5" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d06a-0e47-e712-a574"/>
+      </constraints>
       <profiles>
         <profile name="Dark Elf Crossbowmen" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6c51-43d5-69bd-6523">
           <characteristics>
@@ -4478,9 +4665,42 @@ Note that this special rule does not apply to this model’s mount (should it ha
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="90f2-59ff-bb9c-eae0" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="d06a-0e47-e712-a574">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sisters of Slaughter" hidden="false" id="9db4-727d-d647-9996" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="4667-dc17-8b2c-5b75"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="4667-dc17-8b2c-5b75">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Daughters Of Khaine" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7cca-860f-760e-15eb">
           <characteristics>

--- a/Dwarfen Mountain Holds.cat
+++ b/Dwarfen Mountain Holds.cat
@@ -6211,6 +6211,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="eb88-4a12-0a54-9315"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="eb88-4a12-0a54-9315">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="ff65-5ffb-12a2-2f50" name="Ranger" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" flatten="true" sortIndex="1">
           <costs>
@@ -6429,6 +6448,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dwarf Warriors" hidden="false" id="b969-2677-1d5a-8449">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="a107-e57d-676d-d0a3"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="a107-e57d-676d-d0a3">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Dwarf Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="841b-440-95e0-d75f">
           <characteristics>
@@ -6691,6 +6729,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Quarrellers" hidden="false" id="c4a9-d38a-2612-4a9a">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d171-c392-c433-cd99"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="d171-c392-c433-cd99">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Quarreller" hidden="false" id="eb1d-9ea-e98-a454" flatten="true" sortIndex="1">
           <costs>
@@ -6877,6 +6934,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ironbreakers" hidden="false" id="ed17-90ba-6e91-d0d6">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="290a-9c02-e421-5d6b"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="290a-9c02-e421-5d6b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ironbreakers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="ebf1-44bf-b17b-7537">
           <characteristics>
@@ -7165,6 +7241,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5599-b3bf-46e8-3ebc"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="5599-b3bf-46e8-3ebc">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="e60a-105b-669a-f046" name="Longbeard" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -7437,6 +7532,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Thunderers" hidden="false" id="dd27-431-f28d-8698">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="426b-2a7e-602a-98f9"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="426b-2a7e-602a-98f9">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Thunderer" hidden="false" id="f776-e8d1-449f-6b99" flatten="true" sortIndex="1">
           <costs>
@@ -7672,6 +7786,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hammerers" hidden="false" id="cc19-cbda-7503-8be5">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2a10-1ee8-4b08-3d89"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2a10-1ee8-4b08-3d89">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Hammerers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6fb1-1771-1d7d-c69d">
           <characteristics>
@@ -7923,6 +8056,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Irondrakes" hidden="false" id="65a7-9001-2425-683f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="db42-c712-fd5c-e7e5"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="db42-c712-fd5c-e7e5">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Irondrakes" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="aa33-8031-7eb9-1090">
           <characteristics>
@@ -8218,6 +8370,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Miners" hidden="false" id="9eec-40b7-179-c6bf">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="78a6-11a7-caef-39d8"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="78a6-11a7-caef-39d8">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Miner" hidden="false" id="b59d-d501-45b5-1d6a" sortIndex="1">
           <costs>
@@ -8531,6 +8702,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </costs>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Slayers" hidden="false" id="9f80-e41f-57be-c779">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="71ff-1120-8dbd-49ca"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="71ff-1120-8dbd-49ca">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Slayers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6190-c4f9-cf7d-2ef9">
           <characteristics>
@@ -11552,6 +11742,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Royal Clan Warriors" hidden="false" id="e6a8-b8bd-0e50-eba0">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="539e-5268-93c9-9eb0"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="539e-5268-93c9-9eb0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <infoGroups>
         <infoGroup name="Special Rules" id="bec3-7d67-1d67-da40" hidden="false">
           <infoLinks>
@@ -11943,6 +12152,25 @@ When a unit of Miners would arrive onto the battlefield as Reserves, it can be p
       </selectionEntries>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Brotherhood of Grimnir" hidden="false" id="a131-b0cf-8a0d-0837" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c81d-3323-3f8d-f431"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c81d-3323-3f8d-f431">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Brotherhood of Grimnir" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e634-0b3a-501f-1c70">
           <characteristics>

--- a/Grand Cathay.cat
+++ b/Grand Cathay.cat
@@ -2080,6 +2080,9 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
       </selectionEntries>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Jade Warriors" hidden="false" id="c5f3-400c-e140-fb65">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1d6f-066a-3861-2532"/>
+      </constraints>
       <profiles>
         <profile name="Jade Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d206-a457-7642-5fa8">
           <characteristics>
@@ -2350,9 +2353,26 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
             <condition type="atLeast" value="1" field="selections" scope="self" childId="21d1-ad09-6909-eee6" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="1d6f-066a-3861-2532">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Jade Lancer" hidden="false" id="4cc7-7623-fd30-5dc2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6d89-6aed-905b-d3a0"/>
+      </constraints>
       <profiles>
         <profile name="Jade Lancer" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="cf5e-46d5-213f-8a74">
           <characteristics>
@@ -2616,6 +2636,20 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
             <condition type="atLeast" value="1" field="selections" scope="self" childId="c656-5013-2064-d552" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="6d89-6aed-905b-d3a0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Cathayan Sentinel" hidden="false" id="9189-88d5-e177-bf2a">
@@ -2754,6 +2788,25 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
       </selectionEntries>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Cathayan Grand Cannon" hidden="false" id="0d66-ce16-3768-0611" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0056-4352-6c42-5a7c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0056-4352-6c42-5a7c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Grand Cannon" hidden="false" id="fe5c-8679-3e0b-f1a9" sortIndex="1">
           <infoLinks>
@@ -2835,6 +2888,25 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Fire Rain Rocket Battery" hidden="false" id="81e7-7528-d4e5-ec71" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="bf09-bfb4-c9ef-b5de"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="bf09-bfb4-c9ef-b5de">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Fire Rain Rocket" hidden="false" id="8dce-193e-5698-f1fc" sortIndex="1">
           <infoLinks>
@@ -3199,6 +3271,9 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Peasant Levy" hidden="false" id="20af-747a-31ff-ea0a">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5a5c-0e90-96a7-a551"/>
+      </constraints>
       <profiles>
         <profile name="Peasant Levy" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b196-1257-6898-d52a">
           <characteristics>
@@ -3444,6 +3519,20 @@ The crew of any war machine joined by an Ogre Loader gains a +1 modifier to its 
         <modifier type="add" value="8d04-b54d-2e44-abd2" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="self" childId="2489-2405-0601-d07d" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="5a5c-0e90-96a7-a551">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/High Elf Realms.cat
+++ b/High Elf Realms.cat
@@ -1152,6 +1152,25 @@
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Elven Spearmen" hidden="false" id="93df-6c31-ecb8-bc77">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="fd52-64a5-127a-b5a8"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="fd52-64a5-127a-b5a8">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Elven Spearman" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="39e9-f3d5-30c2-8d84">
           <characteristics>
@@ -3656,6 +3675,25 @@
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Elven Archers" hidden="false" id="bf06-d67a-9359-a1eb">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6088-2dd2-9f47-0032"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6088-2dd2-9f47-0032">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Elven Archer" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="da8-ef41-8bf8-33f3">
           <characteristics>
@@ -4026,6 +4064,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Lothern Sea Guard" hidden="false" id="12f4-405f-3fb5-75dc">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8920-3ed4-ca67-7d9c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8920-3ed4-ca67-7d9c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Lothern Sea Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f4e5-5d64-288f-93">
           <characteristics>
@@ -4382,6 +4439,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="White Lions of Chrace" hidden="false" id="24cb-795c-4110-f2d1">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="4699-26b1-bf15-d2dd"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="4699-26b1-bf15-d2dd">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="White Lions of Chrace" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="1dbe-779e-6137-5f5f">
           <characteristics>
@@ -4572,6 +4648,25 @@
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Swordmasters of Hoeth" hidden="false" id="242d-b760-d547-df4c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="4f82-0cef-8346-5703"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="4f82-0cef-8346-5703">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Swordmasters of Hoeth" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="1f88-1ff3-7596-772a">
           <characteristics>
@@ -4726,6 +4821,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Phoenix Guard" hidden="false" id="13c7-a5e6-3b4d-23b6">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="dc47-e57a-30b3-c9b6"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="dc47-e57a-30b3-c9b6">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Phoenix Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e279-d240-c1-d74f">
           <characteristics>
@@ -4875,6 +4989,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Shadow Warriors" hidden="false" id="c62c-5e5-1191-14">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f3f7-ae83-7aea-e7cc"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f3f7-ae83-7aea-e7cc">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Shadow Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="cee-4a0a-7910-d8b0">
           <characteristics>
@@ -5061,6 +5194,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sisters of Avelorn" hidden="false" id="ec7-689f-9d5b-cdc2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="378e-a29c-b24f-2d4f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="378e-a29c-b24f-2d4f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Sisters of Avelorn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f51-36c3-78c1-fbd1">
           <characteristics>
@@ -5201,6 +5353,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ellyrian Reavers" hidden="false" id="d02f-84c5-86bf-ff87">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b1c7-af14-2641-f6e7"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b1c7-af14-2641-f6e7">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ellyrian Reavers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f394-3c07-f174-abe4">
           <characteristics>
@@ -5563,6 +5734,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Silver Helms" hidden="false" id="e9b1-22cd-7328-5fde">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="006d-6d16-40a0-b993"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="006d-6d16-40a0-b993">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Silver Helms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3af7-3749-1b26-cd00">
           <characteristics>
@@ -5713,6 +5903,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dragon Princes" hidden="false" id="3660-5d1a-17d4-588c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8b12-59f6-e596-8242"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8b12-59f6-e596-8242">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Dragon Princes" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="eda1-11da-4a40-149c">
           <characteristics>
@@ -7566,6 +7775,25 @@
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ship&apos;s Company" hidden="false" id="ce15-1811-01c5-2348">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c034-1cbd-2783-f05d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c034-1cbd-2783-f05d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ship&apos;s Company" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="52a1-21ae-6a45-be6a">
           <characteristics>
@@ -7894,6 +8122,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Lion Guard" hidden="false" id="e76a-6460-5457-a60d">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8990-a7de-7560-a80d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8990-a7de-7560-a80d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Lion Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6920-ce72-8f34-83e1">
           <characteristics>
@@ -8030,6 +8277,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chracian Woodsmen" hidden="false" id="fb73-811c-02a4-df6f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="22eb-2014-46b4-95b4"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="22eb-2014-46b4-95b4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chracian Woodsmen" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e092-8659-67a5-bc19">
           <characteristics>

--- a/Lizardmen.cat
+++ b/Lizardmen.cat
@@ -1511,6 +1511,25 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Temple Guard" hidden="false" id="2ce4b83e-f908d88" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8565-7086-b51d-8ea0"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8565-7086-b51d-8ea0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Temple Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="147d1c0c-b628f856">
           <characteristics>
@@ -1674,6 +1693,9 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Saurus Warriors" hidden="false" id="474230e6-c10edff0" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="59bf-0678-dd53-0998"/>
+      </constraints>
       <profiles>
         <profile name="Saurus Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="1981c894-1c6cb79e">
           <characteristics>
@@ -1821,9 +1843,26 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="1e63bf4e-dc2d6558" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="59bf-0678-dd53-0998">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skink Skirmishers" hidden="false" id="a08674da-5e53eec4" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d909-08ad-3c5b-8256"/>
+      </constraints>
       <profiles>
         <profile name="Skink Skirmishers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d0985040-c1f9338a">
           <characteristics>
@@ -1996,9 +2035,42 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="850a8da-ae2c82c4" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="d909-08ad-3c5b-8256">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chameleon Skinks" hidden="false" id="3da3f6e5-863f87db" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="cff4-9659-77e7-c983"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="cff4-9659-77e7-c983">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chameleon Skinks" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f4cfb783-77db26b1">
           <characteristics>
@@ -2087,6 +2159,25 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Kroxigor" hidden="false" id="cc5d495b-840464e9" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2fd4-ed8a-737c-65c1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2fd4-ed8a-737c-65c1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Kroxigor" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5f0134c9-5ab6cc9f">
           <characteristics>
@@ -2170,6 +2261,25 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Jungle Swarms" hidden="false" id="de3e8786-d3a44b10" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0780-323d-c776-2f07"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0780-323d-c776-2f07">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Jungle Swarms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7a81e5b4-e25ad0be">
           <characteristics>
@@ -2221,6 +2331,39 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Salamander Packs" hidden="false" id="dafc1748-451bdbf2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="984e-e64b-33ea-fd83"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="984e-e64b-33ea-fd83">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="984e-e64b-33ea-fd83">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Salamander Packs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="81549bce-b3b35dd8">
           <characteristics>
@@ -2316,6 +2459,39 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Razordon Packs" hidden="false" id="56a82633-8f1b15e1" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f868-3954-2805-73e4"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f868-3954-2805-73e4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="f868-3954-2805-73e4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Razordon Packs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="c91e20a1-5836b677">
           <characteristics>
@@ -2412,6 +2588,25 @@ This character has a 5+ Ward save against any wounds suffered</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Cold One Riders" hidden="false" id="24416dfd-4d1e5933" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2155-22df-6cee-7661"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2155-22df-6cee-7661">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Cold One Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9226b9fb-ebc8f789">
           <characteristics>

--- a/Mercenaries.cat
+++ b/Mercenaries.cat
@@ -2,6 +2,25 @@
 <catalogue library="true" id="12a0-32cd-11d6-f952" name="Mercenaries" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="99" revision="41" authorUrl="www.newrecruit.eu" authorContact="Discord: vflam" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Badlands Ogre Bulls" hidden="false" id="a4af-ea3a-49ea-d56e" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="325f-e6fd-75d6-6453"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="325f-e6fd-75d6-6453">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Badlands Ogre Bulls" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="fbd5-1dc2-61a9-7c85">
           <characteristics>
@@ -354,6 +373,25 @@
       </selectionEntries>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Imperial Dwarf Mercenaries" hidden="false" id="5ab0-0b8b-6b08-ce54">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6d1e-d423-3aba-f6ba"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6d1e-d423-3aba-f6ba">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink name="Faction: Dwarfen Mountain Holds" hidden="false" id="4b02-906e-4f2a-d88c" targetId="f4fd-aa79-6ff3-1ea9" primary="false"/>
       </categoryLinks>
@@ -654,6 +692,25 @@
       <costs>
         <cost name="pts" typeId="points" value="115"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5cd9-a948-cfe1-addf"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="5cd9-a948-cfe1-addf">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink targetId="f4fd-aa79-6ff3-1ea9" id="121f-2a98-f4b2-e3d9" primary="false" name="Faction: Dwarfen Mountain Holds"/>
       </categoryLinks>
@@ -925,6 +982,25 @@
       </selectionEntries>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Imperial Ogres" hidden="false" id="35c8-1830-8069-55b7" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f18a-4d5f-990d-3db3"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f18a-4d5f-990d-3db3">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Imperial Ogres" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e6a3-fce7-2bbe-7797">
           <characteristics>

--- a/Ogre Kingdoms.cat
+++ b/Ogre Kingdoms.cat
@@ -1989,6 +1989,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ogre Bulls" hidden="false" id="263902fd-90b14633" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b550-34b4-2b4a-5d78"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b550-34b4-2b4a-5d78">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ogre Bulls" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="285beefb-f4ac8489">
           <characteristics>
@@ -2210,6 +2229,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ironguts" hidden="false" id="4b1bfec3-a90b33f1" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="88c3-291e-ccd5-5ac2"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="88c3-291e-ccd5-5ac2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ironguts" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a9d12531-cd5f6c07">
           <characteristics>
@@ -2379,6 +2417,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Leadbelchers" hidden="false" id="ba59280-fc0a63ca" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2356-921b-4552-d9ec"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2356-921b-4552-d9ec">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Leadbelchers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4b120226-73562730">
           <characteristics>
@@ -2506,6 +2563,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gnoblar Trappers" hidden="false" id="181f39f8-7c22f5e2" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="df97-76f4-f873-225d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="df97-76f4-f873-225d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Gnoblar Trappers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="10dfa4fe-84ce1448">
           <characteristics>
@@ -2588,6 +2664,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Maneaters" hidden="false" id="a640f5be-851edf08" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0082-70d2-1e2f-552c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0082-70d2-1e2f-552c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Maneaters" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="c1b3898c-f3ff9d6">
           <characteristics>
@@ -2943,6 +3038,25 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gnoblar Fighters" hidden="false" id="78222d23-d2fef151" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b6ef-24e6-03d2-6021"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b6ef-24e6-03d2-6021">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Gnoblar Fighters" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5f49b611-ad961b67">
           <characteristics>
@@ -3023,6 +3137,9 @@ Enemy models removed from play are considered to have been removed from the figh
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Yhetees" hidden="false" id="6559466d-ab811023" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="eaa4-e15b-e438-e52e"/>
+      </constraints>
       <profiles>
         <profile name="Yhetees" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a196aa2b-760c1479">
           <characteristics>
@@ -3139,6 +3256,20 @@ Enemy models removed from play are considered to have been removed from the figh
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="set" value="0" field="eaa4-e15b-e438-e52e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
         </modifier>
       </modifiers>
     </selectionEntry>

--- a/Orc and Goblin Tribes.cat
+++ b/Orc and Goblin Tribes.cat
@@ -2,6 +2,9 @@
 <catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="c997-9d47-72ad-c5f1" name="Orc and Goblin Tribes" gameSystemId="sys-31d1-bf57-53ea-ad55" gameSystemRevision="19" revision="186" authorName="Flammy" battleScribeVersion="2.03" type="catalogue" authorContact="Discord: vflam" authorUrl="www.newrecruit.eu">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Orc Mobs" hidden="false" id="51e8-1471-ce4c-d5dd">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1a91-d0fa-73b5-850c"/>
+      </constraints>
       <profiles>
         <profile name="Orc Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="257d-5056-608-2108">
           <characteristics>
@@ -276,6 +279,20 @@
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="a8bf-d5a9-117a-1b88" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="1a91-d0fa-73b5-850c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Big Un&apos;s" hidden="false" id="e06e-f7ee-cc7f-ec67">
@@ -509,6 +526,7 @@
       <constraints>
         <constraint type="max" value="0" field="selections" scope="force" shared="true" id="848c-d08e-f372-9ae2"/>
         <constraint type="min" value="0" field="selections" scope="force" shared="true" id="9e08-7846-059e-a5b5"/>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2102-5505-363e-6395"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="1" field="848c-d08e-f372-9ae2">
@@ -532,12 +550,29 @@
             <condition type="lessThan" value="1" field="selections" scope="force" childId="0ba6-6cb2-c5f4-904a" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="2102-5505-363e-6395">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink name="Faction: Orc and Goblin Tribes" hidden="false" id="5480-f8c0-d5b5-71d9" primary="false" targetId="96f6-a6de-3328-b74c"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Goblin Mobs" hidden="false" id="6ce4-96c1-6e66-4e65" flatten="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9836-b7d8-8061-4764"/>
+      </constraints>
       <profiles>
         <profile name="Goblin Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6b30-f6b9-24f2-870d">
           <characteristics>
@@ -805,9 +840,42 @@
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="7062-dff1-ac19-8a7c" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="9836-b7d8-8061-4764">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Night Goblin Mobs" hidden="false" id="399b-6e05-9a74-e18f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5895-51bb-a089-8629"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="5895-51bb-a089-8629">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Night Goblin Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d71d-b44f-ed1c-5871">
           <characteristics>
@@ -1071,6 +1139,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Snotling Mobs" hidden="false" id="42b6-c48e-b345-102a">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="44e4-7537-89ef-6651"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="44e4-7537-89ef-6651">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Snotling Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6383-54c3-dfe1-7c2e">
           <characteristics>
@@ -1129,6 +1216,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Common Troll Mobs" hidden="false" id="afd2-472f-d0bd-942f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7b10-fcf9-ef4b-f144"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7b10-fcf9-ef4b-f144">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Common Troll Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3ca3-7615-27ce-8ab0">
           <characteristics>
@@ -1226,6 +1332,25 @@
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="River Troll Mobs" hidden="false" id="a6f0-e007-d5e4-318b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="fe92-fc1d-4b2c-61a4"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="fe92-fc1d-4b2c-61a4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="River Troll Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="18eb-444d-73b-1b09">
           <characteristics>
@@ -1314,6 +1439,25 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Stone Troll Mobs" hidden="false" id="7255-5510-3bf2-87a6">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c435-21a0-9639-ced1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c435-21a0-9639-ced1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Stone Troll Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4da2-fe9f-56c1-b0bc">
           <characteristics>
@@ -1412,6 +1556,9 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Orc Boar Boy Mobs" hidden="false" id="5b90-17e7-7f9c-f674">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="458d-07aa-cdf6-6045"/>
+      </constraints>
       <profiles>
         <profile name="Orc Boar Boy Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="fa03-b035-5b14-4c5a">
           <characteristics>
@@ -1724,9 +1871,42 @@
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="592-dd42-954-f62f" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="458d-07aa-cdf6-6045">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Goblin Spider Rider Mobs" hidden="false" id="f8e2-1ac4-c646-af1c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e823-963a-ef59-20b2"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="e823-963a-ef59-20b2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Goblin Spider Rider Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="71c3-3b22-2e42-478b">
           <characteristics>
@@ -1941,6 +2121,9 @@
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Goblin Wolf Rider Mobs" hidden="false" id="e36d-11d8-5d9a-1198">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9baf-e880-b3e1-84da"/>
+      </constraints>
       <profiles>
         <profile name="Goblin Wolf Rider Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="ff2b-1c5c-b2d5-7717">
           <characteristics>
@@ -2326,9 +2509,42 @@
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="c50b-cede-fd3b-7ab1" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="9baf-e880-b3e1-84da">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Night Goblin Squig Hopper Mobs" hidden="false" id="6949-f50f-89e4-99c8">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f6ee-3280-676b-c79a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f6ee-3280-676b-c79a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Night Goblin Squig Hopper Mobs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="542d-4dda-dc5a-42cd">
           <characteristics>

--- a/Renegade Crowns.cat
+++ b/Renegade Crowns.cat
@@ -771,6 +771,9 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sellswords" hidden="false" id="5e9a-b908-b151-dd11">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="68b8-4bf8-04d9-c5ec"/>
+      </constraints>
       <profiles>
         <profile name="Sellswords" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9dfb-5999-2194-3cac">
           <characteristics>
@@ -977,9 +980,26 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="68b8-4bf8-04d9-c5ec">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Veteran Sellswords" hidden="false" id="78ad-cf06-070e-0af2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d575-e7ab-d870-60e8"/>
+      </constraints>
       <profiles>
         <profile name="Veteran Sellswords" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="fc65-77e5-57cc-31aa">
           <characteristics>
@@ -1219,9 +1239,26 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="d575-e7ab-d870-60e8">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Freeblade Knights" hidden="false" id="4ba9-12e6-f5d5-d21f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5f8f-9177-2ae5-01d0"/>
+      </constraints>
       <profiles>
         <profile name="Freeblade Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="dca3-7929-c3e1-d806">
           <characteristics>
@@ -1399,9 +1436,26 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
             <condition type="atLeast" value="1" field="selections" scope="self" childId="6c41-fb63-576c-4703" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="5f8f-9177-2ae5-01d0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Veteran Freeblade" hidden="false" id="07d6-848b-1741-ae3e">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="23e7-9733-9366-ca22"/>
+      </constraints>
       <profiles>
         <profile name="Veteran Freeblade" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9a97-7ff0-a1ae-d86c">
           <characteristics>
@@ -1596,9 +1650,26 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
             <condition type="atLeast" value="1" field="selections" scope="self" childId="6c41-fb63-576c-4703" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="23e7-9733-9366-ca22">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hireling Outriders" hidden="false" id="b054-af78-cd52-a625">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d46a-9654-dfea-a189"/>
+      </constraints>
       <profiles>
         <profile name="Hireling Outriders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="1a94-e8e0-032c-7322">
           <characteristics>
@@ -1841,6 +1912,20 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
         <modifier type="add" value="cbae-50eb-ec06-7fb4" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="self" childId="8906-917f-76ba-ca24" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="d46a-9654-dfea-a189">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -2185,6 +2270,9 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Border Princes Brigands" hidden="false" id="6159-e51f-882c-9063" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f7c2-839b-574d-8fb2"/>
+      </constraints>
       <profiles>
         <profile name="Border Princes Brigands" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4a24-855f-56da-5239">
           <characteristics>
@@ -2520,6 +2608,20 @@ If a unit with this special rule wishes to adopt Marching Column and march at tr
         <modifier type="add" value="1c49-d35c-2d41-8dcf" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="self" childId="8a05-9b69-cf65-d457" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="f7c2-839b-574d-8fb2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -1677,6 +1677,9 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Stormvermin" hidden="false" id="e615449a-cb6e4084" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9d63-5ccf-74ac-990e"/>
+      </constraints>
       <profiles>
         <profile name="Stormvermin" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="18cede80-dd894fca">
           <characteristics>
@@ -1846,9 +1849,26 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
           </conditions>
           <comment>Renegades</comment>
         </modifier>
+        <modifier type="set" value="0" field="9d63-5ccf-74ac-990e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Clanrats" hidden="false" id="a5aa96a6-178617b0" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7cb5-d24c-9e73-776a"/>
+      </constraints>
       <profiles>
         <profile name="Clanrats" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f1d22cd4-5c97f9de">
           <characteristics>
@@ -2016,6 +2036,20 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
           </conditions>
           <comment>Renegades</comment>
         </modifier>
+        <modifier type="set" value="0" field="7cb5-d24c-9e73-776a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Weapon Team" hidden="false" id="26ff5f14-60499a1e" collective="false" flatten="false">
@@ -2141,6 +2175,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Warplock Jezzails" hidden="false" id="c3a2f71f-1c02cdad" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="127f-5432-0ee2-de05"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="127f-5432-0ee2-de05">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Warplock Jezzails" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="72a1b195-d356238b">
           <characteristics>
@@ -2255,6 +2308,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Rat Swarms" hidden="false" id="be93b446-106a11d0" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1f3f-8222-d0f1-7aa3"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1f3f-8222-d0f1-7aa3">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Rat Swarms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="44ccbf4-201c84fe">
           <characteristics>
@@ -2303,6 +2375,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Packmasters &amp; Master Moulders" hidden="false" id="60e0080b-27e77fd9" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b434-4edb-0a77-69f6"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="b434-4edb-0a77-69f6">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Packmasters &amp; Master Moulders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d044d6b9-fc430e0f">
           <characteristics>
@@ -2335,6 +2426,39 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Rat Ogres" hidden="false" id="cd2d3dc1-4f123b17" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e5b9-071f-9e73-3798"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="e5b9-071f-9e73-3798">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="e5b9-071f-9e73-3798">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Rat Ogres" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="88584be7-444de5b5">
           <characteristics>
@@ -2433,6 +2557,39 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Giant Rats" hidden="false" id="3fe741ef-a68370fd" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8427-8e4f-0269-8d67"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8427-8e4f-0269-8d67">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="8427-8e4f-0269-8d67">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Giant Rats" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="519fe6a5-a55df99b">
           <characteristics>
@@ -2518,6 +2675,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Night Runners" hidden="false" id="caca34eb-55cd4939" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="cd45-243b-9d5b-a965"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="cd45-243b-9d5b-a965">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Night Runners" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9467aa19-38430e6f">
           <characteristics>
@@ -2617,6 +2793,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gutter Runners" hidden="false" id="d8c8b802-ea4e19cc" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9ccb-0eb7-77d7-2cc0"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="9ccb-0eb7-77d7-2cc0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Gutter Runners" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="705ba28-fe9167d2">
           <characteristics>
@@ -2748,6 +2943,25 @@ Any unit that suffers one or more unsaved wounds from this weapon must make a Pa
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Plague Monks" hidden="false" id="dfd168cc-4cf4df16" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="13f2-3acf-f36b-bd2c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="13f2-3acf-f36b-bd2c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Plague Monks" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b0c45c6a-b2e65114">
           <characteristics>

--- a/The Empire of Man - Knightly Order.cat
+++ b/The Empire of Man - Knightly Order.cat
@@ -5195,6 +5195,20 @@
             <repeat value="4" repeats="1" field="points" scope="force" childId="any" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
+        <modifier type="set" value="0" field="921e-04e1-1cf2-8b0b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink name="Faction: The Empire of Man" hidden="false" id="1045-d25c-6c15-b6c3" primary="false" targetId="e5f1-f9ee-d533-b2dc"/>
@@ -5214,6 +5228,7 @@
         <constraint type="max" value="-1" field="points" scope="self" shared="true" id="05d3-ac7e-0e1a-13b9" includeChildSelections="true" includeChildForces="true" percentValue="false">
           <comment>Battle March points</comment>
         </constraint>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="921e-04e1-1cf2-8b0b"/>
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Empire Knights" hidden="true" id="0464-462f-4958-635d">
@@ -5678,6 +5693,20 @@
             <repeat value="4" repeats="1" field="points" scope="force" childId="any" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
+        <modifier type="set" value="0" field="8c9d-c122-8585-9567">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint type="max" value="-1" field="points" scope="self" shared="true" id="7f36-91cd-b0eb-a51d" includeChildSelections="true" includeChildForces="true" percentValue="false">
@@ -5686,6 +5715,7 @@
         <constraint type="max" value="-1" field="points" scope="self" shared="true" id="d7e0-3845-494e-4f44" includeChildSelections="true" includeChildForces="true" percentValue="false">
           <comment>Battle March points</comment>
         </constraint>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8c9d-c122-8585-9567"/>
       </constraints>
     </selectionEntry>
   </selectionEntries>

--- a/The Empire of Man.cat
+++ b/The Empire of Man.cat
@@ -2667,6 +2667,9 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="State Troops" hidden="false" id="1b7e-3a24-5a85-7f02">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2710-e6ca-5025-85a4"/>
+      </constraints>
       <profiles>
         <profile name="State Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="f1ab-bf98-4f-395a">
           <characteristics>
@@ -2831,6 +2834,20 @@ Note that any special rules granted by these upgrades do not apply to the models
         <modifier type="remove" value="5e89-9cfa-f74-43ea" field="category">
           <conditions>
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="2710-e6ca-5025-85a4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -3022,6 +3039,7 @@ Note that any special rules granted by these upgrades do not apply to the models
       </infoGroups>
       <constraints>
         <constraint type="max" value="0" field="selections" scope="roster" shared="true" id="cb14-a1aa-8403-e3d9" includeChildSelections="true"/>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7927-2178-d6b1-def7"/>
       </constraints>
       <modifiers>
         <modifier type="increment" value="1" field="cb14-a1aa-8403-e3d9">
@@ -3034,6 +3052,20 @@ Note that any special rules granted by these upgrades do not apply to the models
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="7927-2178-d6b1-def7">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <categoryLinks>
         <categoryLink name="Regimental Unit" hidden="false" id="9690-40db-b160-4282" targetId="5e89-9cfa-f74-43ea" primary="false"/>
@@ -3041,6 +3073,9 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="State Missile Troops" hidden="false" id="5f37-778f-edf0-1fae">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="18ac-da55-5044-17ad"/>
+      </constraints>
       <profiles>
         <profile name="State Missile Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="883c-b95a-b034-e026">
           <characteristics>
@@ -3361,9 +3396,42 @@ Note that any special rules granted by these upgrades do not apply to the models
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="18ac-da55-5044-17ad">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Free Company Militia" hidden="false" id="bd9f-3c86-c12a-fbb1">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c369-ca96-8057-fda1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c369-ca96-8057-fda1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Free Company Milita" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b4e1-eef5-8f0d-e7e1">
           <characteristics>
@@ -3467,6 +3535,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Empire Archers" hidden="false" id="9737-2bec-4f15-d7ca">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6a2f-14de-d8f1-8e91"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6a2f-14de-d8f1-8e91">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Empire Archers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="179c-4b62-af05-3887">
           <characteristics>
@@ -3588,6 +3675,9 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Empire Greatswords" hidden="false" id="499d-722a-5283-6ca5">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b2e1-f275-dd26-9683"/>
+      </constraints>
       <profiles>
         <profile name="Empire Greatswords" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5a29-b9a2-23e0-2202">
           <characteristics>
@@ -3831,9 +3921,42 @@ Note that any special rules granted by these upgrades do not apply to the models
             <condition type="atLeast" value="1" field="selections" scope="self" childId="551d-34fe-3832-416d" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="b2e1-f275-dd26-9683">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Flagellants" hidden="false" id="68ee-4733-e734-10b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="e8ff-4a9d-4cca-d448"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="e8ff-4a9d-4cca-d448">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Flagellants" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d360-5846-7251-9b25">
           <characteristics>
@@ -3937,6 +4060,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Pistoliers" hidden="false" id="aa4f-ba89-89d4-91d5">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c480-669c-813f-9d16"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c480-669c-813f-9d16">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Pistolier" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d50b-8a15-f5fe-8d0f">
           <characteristics>
@@ -4138,6 +4280,9 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Outriders" hidden="false" id="8ab0-72be-ce53-8df4">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="a343-171c-0462-5ef6"/>
+      </constraints>
       <profiles>
         <profile name="Outrider" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="58ce-74ed-6996-2852">
           <characteristics>
@@ -4293,9 +4438,42 @@ Note that any special rules granted by these upgrades do not apply to the models
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="173f-107c-785f-5129" shared="true" childName="Veteran Outriders" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="a343-171c-0462-5ef6">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Empire Knights" hidden="false" id="1631-bc82-ad96-3c19">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="02e9-7beb-aa1e-3f65"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="02e9-7beb-aa1e-3f65">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Empire Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b487-4701-bf7f-8c93">
           <characteristics>
@@ -4629,6 +4807,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Inner Circle Knights" hidden="false" id="3407-96f3-26d4-473f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1dbf-565d-aa44-17fb"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1dbf-565d-aa44-17fb">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Inner Circle Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a962-65d6-f2bc-270e">
           <characteristics>
@@ -6316,6 +6513,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Empire Road Wardens" hidden="false" id="fa7d-66d7-a667-6bfa" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="a912-a7ca-b818-b175"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="a912-a7ca-b818-b175">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Empire Road Wardens" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="418a-8e34-168c-db86">
           <characteristics>
@@ -6735,6 +6951,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </infoGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Teutogen Guard" hidden="false" id="2c74-7796-4720-4326">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="6ba7-79e0-a470-677b"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="6ba7-79e0-a470-677b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Teutogen Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7b26-ee02-5175-d704">
           <characteristics>
@@ -7329,6 +7564,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Nuln State Troops" hidden="false" id="079c-a63e-1ece-18e2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0e60-8c61-e3ed-794a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0e60-8c61-e3ed-794a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="State Trooper" hidden="false" id="960d-4c69-c34d-0fbb" sortIndex="1">
           <constraints>
@@ -7446,6 +7700,25 @@ Note that any special rules granted by these upgrades do not apply to the models
         <selectionEntryGroup name="Detachments" id="348e-2b0e-ad2e-6fb6" hidden="false" sortIndex="3">
           <selectionEntries>
             <selectionEntry type="unit" import="true" name="State Missile Troops" hidden="false" id="b941-a029-a9b0-0fec" sortIndex="1">
+              <constraints>
+                <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="251f-8e71-4ea7-8c83"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="0" field="251f-8e71-4ea7-8c83">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <profiles>
                 <profile name="State Missile Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="7c60-c2ae-750c-530f">
                   <characteristics>
@@ -7615,6 +7888,25 @@ Note that any special rules granted by these upgrades do not apply to the models
               </categoryLinks>
             </selectionEntry>
             <selectionEntry type="unit" import="true" name="State Troops" hidden="false" id="e46a-0ae1-8489-4b1d" sortIndex="2">
+              <constraints>
+                <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f2c7-2ea0-ceff-443b"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="0" field="f2c7-2ea0-ceff-443b">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <profiles>
                 <profile name="State Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9d88-0f9a-7629-4562">
                   <characteristics>
@@ -7742,6 +8034,25 @@ Note that any special rules granted by these upgrades do not apply to the models
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Nuln Veteran State Troops" hidden="false" id="b8bd-1618-29c9-1f93">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="f3a5-367b-9dbb-739c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="f3a5-367b-9dbb-739c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Veteran State Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="efd9-1ffc-b914-5566">
           <characteristics>
@@ -7894,6 +8205,25 @@ Note that any special rules granted by these upgrades do not apply to the models
         <selectionEntryGroup name="Detachments" id="0988-dc15-f6e2-17fd" hidden="false" sortIndex="3">
           <selectionEntries>
             <selectionEntry type="unit" import="true" name="State Troops" hidden="false" id="fed7-164e-cc85-9f00" sortIndex="2">
+              <constraints>
+                <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2f07-8675-2dc6-50ae"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="0" field="2f07-8675-2dc6-50ae">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <profiles>
                 <profile name="State Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b945-57d7-c439-f144">
                   <characteristics>
@@ -7992,6 +8322,25 @@ Note that any special rules granted by these upgrades do not apply to the models
               </categoryLinks>
             </selectionEntry>
             <selectionEntry type="unit" import="true" name="State Missile Troops" hidden="false" id="4947-26e0-17b6-3d45" sortIndex="1">
+              <constraints>
+                <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="b5d5-d254-25a2-aff9"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="0" field="b5d5-d254-25a2-aff9">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+                  <comment>Battle March: maximum unit strength 20</comment>
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+                    <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
               <profiles>
                 <profile name="State Missile Troops" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9135-1acf-3e91-f605">
                   <characteristics>

--- a/Tomb Kings of Khemri.cat
+++ b/Tomb Kings of Khemri.cat
@@ -2441,6 +2441,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Tomb Guard" hidden="false" id="57fe-aa08-f68-150f">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7637-15ac-39a1-e8cf"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7637-15ac-39a1-e8cf">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Tomb Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d036-b5f8-d94b-b8cc">
           <characteristics>
@@ -2671,6 +2690,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Warriors" hidden="false" id="310d-5ffd-d45b-60bb">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="250a-14f1-9d56-41ae"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="250a-14f1-9d56-41ae">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Warrior" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="d8d1-9fb1-6436-5a35">
           <characteristics>
@@ -2897,6 +2935,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Archers" hidden="false" id="e2e4-9740-3e51-c72d">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="1846-f577-ef47-2aac"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="1846-f577-ef47-2aac">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Archers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3ecc-ce2d-cc10-4b37">
           <characteristics>
@@ -3181,6 +3238,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ushabti" hidden="false" id="81e7-bf62-d1a1-9693">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="883e-4497-8fdd-89ac"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="883e-4497-8fdd-89ac">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Ushabti" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a10d-a963-526a-98ec">
           <characteristics>
@@ -3305,6 +3381,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Tomb Swarms" hidden="false" id="4d7a-245c-7e2c-27af">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0959-62ce-6f2a-fa11"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0959-62ce-6f2a-fa11">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Tomb Swarms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2442-7733-fa54-5dac">
           <characteristics>
@@ -3371,6 +3466,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Carrion" hidden="false" id="38d7-eaad-2a14-e42a">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="df83-526c-f5ac-7b1c"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="df83-526c-f5ac-7b1c">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Carrion" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="da68-4d38-597f-ed36">
           <characteristics>
@@ -3427,6 +3541,9 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Horse Archers" hidden="false" id="ccfd-b30b-4a66-1b31">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="de0f-da4d-0bb7-7ba2"/>
+      </constraints>
       <profiles>
         <profile name="Skeleton Horse Archers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="52f-5679-a622-7dda">
           <characteristics>
@@ -3604,9 +3721,42 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
             <condition type="atLeast" value="1" field="selections" scope="self" childId="4d8d-7fe6-6f8a-9959" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="de0f-da4d-0bb7-7ba2">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Horsemen" hidden="false" id="3aa7-ad25-7cea-ce6b">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="cb69-bde9-21cd-8cab"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="cb69-bde9-21cd-8cab">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Horsemen" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5c29-4e8a-13c4-297c">
           <characteristics>
@@ -4129,6 +4279,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Chariots" hidden="false" id="bda8-d5bc-866e-92b6">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8384-e7a1-2420-d9ee"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8384-e7a1-2420-d9ee">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntryGroups>
         <selectionEntryGroup name="Command" hidden="false" id="c6e6-4504-73d0-e7c4" sortIndex="2">
           <selectionEntries>
@@ -5254,6 +5423,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Infantry Cohort" hidden="false" id="d53d-d4a2-33fc-6b5e" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8589-dcc7-754c-876e"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8589-dcc7-754c-876e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Infatry Cohorts" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="de7-bef1-9c39-5e3d">
           <characteristics>
@@ -5531,6 +5719,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Venerable Ushabti" hidden="false" id="1027-1a96-82a2-a95f" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="407a-7505-8997-c462"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="407a-7505-8997-c462">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Venerable Ushabti" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b346-430e-fc7c-96ff">
           <characteristics>
@@ -5630,6 +5837,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Cavalry Cohort" hidden="false" id="c72d4456-2206dd20" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="aa07-6a7c-7576-dcdb"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="aa07-6a7c-7576-dcdb">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Cavalry Cohort" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="693a7484-26d5664e">
           <characteristics>
@@ -6044,6 +6270,25 @@ However, if this model casts the Light of Death Bound spell, this Bound spell wi
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Tomb Guard Chariots" hidden="false" id="b66d-46bf-9e6c-ea97" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="550e-102d-4a5b-b85f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="550e-102d-4a5b-b85f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="7dce-b0f0-2217-2820" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Tomb Guard Chariots" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4d29-7dfb-3b09-6d38">
           <characteristics>

--- a/Vampire Counts.cat
+++ b/Vampire Counts.cat
@@ -2398,6 +2398,9 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Grave Guard" hidden="false" id="2c65c970-45a4dd3a" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="bc2a-3254-3385-2edf"/>
+      </constraints>
       <profiles>
         <profile name="Grave Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="354b3616-662740e0">
           <characteristics>
@@ -2590,9 +2593,42 @@ Resurrected models are added to the front rank until it reaches the minimum requ
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="6b713127-4af5a0f5" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="bc2a-3254-3385-2edf">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skeleton Warriors" hidden="false" id="c6eca90e-7fa10118" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="da8e-a207-71e6-070b"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="da8e-a207-71e6-070b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skeleton Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="6d75dc1c-d1cafc26">
           <characteristics>
@@ -2795,6 +2831,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Zombies" hidden="false" id="51cffed9-4042bd2f" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="290f-f4cb-295c-4ce7"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="290f-f4cb-295c-4ce7">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Zombies" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5ee6639f-34c6d62d">
           <characteristics>
@@ -2884,6 +2939,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Crypt Ghouls" hidden="false" id="efbab8cc-7313af16" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="489a-e564-73b7-96b1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="489a-e564-73b7-96b1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Crypt Ghouls" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a287ac6a-dc0f2114">
           <characteristics>
@@ -2966,6 +3040,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Crypt Horrors" hidden="false" id="475a2b9f-6b5c5e2d" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9442-4509-65dc-a1f4"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="9442-4509-65dc-a1f4">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Crypt Horrors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="ce3af615-8b01440b">
           <characteristics>
@@ -3055,6 +3148,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Bat Swarms" hidden="false" id="a0676ab6-5e2b8f80" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c4c2-2396-1eec-929d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c4c2-2396-1eec-929d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="db92-54fd-e023-d69f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Bat Swarms" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="c03e4364-d531deae">
           <characteristics>
@@ -3110,6 +3222,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Vargheists" hidden="false" id="83c603e2-69f18f2c" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c81e-30dc-7ad2-a112"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c81e-30dc-7ad2-a112">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Vargheists" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="325f9d88-deb13032">
           <characteristics>
@@ -3206,6 +3337,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Fell Bats" hidden="false" id="95bea3a5-509ece9b" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7ed4-c933-8be9-c9b6"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7ed4-c933-8be9-c9b6">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Fell Bats" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="9a6dbdc3-19d6faf1">
           <characteristics>
@@ -3317,6 +3467,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Blood Knights" hidden="false" id="73d186ca-2ce7f1f4" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5b0a-d9e1-89de-6242"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="5b0a-d9e1-89de-6242">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Blood Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2d8d630-189983fa">
           <characteristics>
@@ -3532,6 +3701,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Black Knights" hidden="false" id="3139650b-e88df4d9" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0916-f217-d49d-baae"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0916-f217-d49d-baae">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Black Knights" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="124cd3b9-ec23230f">
           <characteristics>
@@ -3724,6 +3912,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dire Wolves" hidden="false" id="85ad2a06-6189d990" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="718c-9b18-092d-529b"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="718c-9b18-092d-529b">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Dire Wolves" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="30925834-db53af3e">
           <characteristics>
@@ -3807,6 +4014,25 @@ Resurrected models are added to the front rank until it reaches the minimum requ
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hexwraiths" hidden="false" id="22a70d4b-66cc5b19" collective="false">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="190d-8860-40db-344d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="190d-8860-40db-344d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Hexwraiths" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2c5b0b79-7e819ccf">
           <characteristics>

--- a/Warriors of Chaos.cat
+++ b/Warriors of Chaos.cat
@@ -2187,6 +2187,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chosen Chaos Warriors" hidden="false" id="42b3-1ede-8566-e53d">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="3a1f-4b68-107e-3b5e"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="3a1f-4b68-107e-3b5e">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chosen Chaos Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a5df-defa-b98b-9470">
           <characteristics>
@@ -2414,6 +2433,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Warriors" hidden="false" id="c166-6219-6b1c-412c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="49a3-a350-abec-7f1f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="49a3-a350-abec-7f1f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Warriors" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a94e-1de6-b4fc-291c">
           <characteristics>
@@ -2613,6 +2651,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Marauders" hidden="false" id="8573-1345-8484-74cb">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="2700-77c9-4952-c8ed"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="2700-77c9-4952-c8ed">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Marauders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="462f-2d01-84f1-7017">
           <characteristics>
@@ -2867,6 +2924,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Forsaken" hidden="false" id="1951-80d7-6aa4-acdd">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="682b-e319-8678-4b17"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="682b-e319-8678-4b17">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="ca7e-d004-ccde-caf3" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Forsaken" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="4385-dac3-b546-bc54">
           <characteristics>
@@ -2963,6 +3039,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="d4a3-9825-37bf-9abd"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="d4a3-9825-37bf-9abd">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="7dce-a3f2-535-af3" name="Chaos Knight" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -3168,6 +3263,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       <costs>
         <cost typeId="points" name="pts" value="0"/>
       </costs>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0c44-491a-b40c-8569"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0c44-491a-b40c-8569">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="5165-d052-cfc2-5887" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <selectionEntries>
         <selectionEntry id="363c-8a4f-50e1-7adb" name="Chosen Chaos Knight" type="model" collective="false" hidden="false" publicationId="3a81ff07--pubd1e638" sortIndex="1">
           <costs>
@@ -3514,6 +3628,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Chaos Warhounds" hidden="false" id="c2cc-8da1-a926-e033">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="be26-99ad-24e0-4c87"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="be26-99ad-24e0-4c87">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Chaos Warhound" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="33e1-7b14-af3-1188">
           <characteristics>
@@ -3880,6 +4013,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Marauder Horsemen" hidden="false" id="10a8-69ca-b180-fad8">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="bc37-414f-cedf-b1af"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="bc37-414f-cedf-b1af">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Marauder Horsemen" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="2d64-aa24-ab5c-1db">
           <characteristics>
@@ -4716,6 +4868,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Marauder Tribe Berserkers" hidden="false" id="0094-ce31-f1e4-9b76">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="c1ff-0ef0-f6a8-ff5f"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="c1ff-0ef0-f6a8-ff5f">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Marauder Tribe Berserkers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="66a1-e1fc-8d81-6c75">
           <characteristics>
@@ -4891,6 +5062,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Marauder Tribe Huscarls" hidden="false" id="2f71-73ea-2d03-e414">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="35e7-db22-7bed-b203"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="35e7-db22-7bed-b203">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Marauder Tribe Huscarls" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="91c2-5109-ae97-22de">
           <characteristics>
@@ -5139,6 +5329,25 @@ Note that, should a Bretonnian army accept the challenge, it counts as having pr
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Skin Wolves" hidden="false" id="0fc9-8c14-c91a-60b8">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="989d-dcbd-4aba-a70d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="989d-dcbd-4aba-a70d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Skin Wolves" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5680-bdf6-e94e-3424">
           <characteristics>

--- a/Wood Elf Realms.cat
+++ b/Wood Elf Realms.cat
@@ -874,6 +874,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
   </sharedProfiles>
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Wildwood Rangers" hidden="false" id="d37c-a95d-615e-71d9">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="febf-a18b-f1c4-7a84"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="febf-a18b-f1c4-7a84">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Wildwood Rangers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="20df-6ef2-cb23-57b4">
           <characteristics>
@@ -1037,6 +1056,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Deepwood Scouts" hidden="false" id="9264-289b-db3a-5b8d">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7c72-3012-e787-57e6"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7c72-3012-e787-57e6">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Deepwood Scout" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a2cb-fc36-7a20-75c4">
           <characteristics>
@@ -1175,6 +1213,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Eternal Guard" hidden="false" id="d3d1-dd14-80c2-840e">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9de3-49a4-4986-766a"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="9de3-49a4-4986-766a">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Eternal Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="e13e-373a-d07e-fd81">
           <characteristics>
@@ -1408,6 +1465,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Glade Guard" hidden="false" id="886b-7a97-d451-3f0c">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="bb13-ae46-e619-36ab"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="bb13-ae46-e619-36ab">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Glade Guard" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="ea9f-ec1b-c2f2-602d">
           <characteristics>
@@ -1662,6 +1738,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Wardancers" hidden="false" id="4a01-6b67-783-6d3a">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="fdcb-e625-bf31-f69d"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="fdcb-e625-bf31-f69d">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Wardancers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="524e-c976-560d-6c26">
           <characteristics>
@@ -1822,6 +1917,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Waywatchers" hidden="false" id="a167-14b-f89a-2f11">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="7844-c723-6049-1361"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="7844-c723-6049-1361">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Waywatchers" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="b523-303b-29d9-b051">
           <characteristics>
@@ -1985,6 +2099,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dryads" hidden="false" id="1ae5-ebd2-c2f0-74da">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="0063-4080-b67c-cab1"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="0063-4080-b67c-cab1">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Dryads" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="63dc-e027-2308-f039">
           <characteristics>
@@ -2120,6 +2253,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Tree Kin" hidden="false" id="ff64-94cc-3afd-5333">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="8bbd-5937-4ce5-86ae"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="8bbd-5937-4ce5-86ae">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="7" field="selections" scope="self" childId="5c55-f9d6-b181-92f8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Tree Kin" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3c28-45e8-ae5a-1d41">
           <characteristics>
@@ -3932,6 +4084,9 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Glade Riders" hidden="false" id="b811-3815-bff1-1680">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="5d8e-8336-8e7d-b3a0"/>
+      </constraints>
       <profiles>
         <profile name="Glade Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="3512-3d63-ebce-3810">
           <characteristics>
@@ -4222,6 +4377,20 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
             <condition type="atLeast" value="1" field="selections" scope="root-entry" childId="5c0e-2f3e-6cc8-bddda" shared="true" includeChildSelections="true"/>
           </conditions>
         </modifier>
+        <modifier type="set" value="0" field="5d8e-8336-8e7d-b3a0">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
     </selectionEntry>
     <selectionEntry type="model" import="true" name="Elven Steed" hidden="false" id="8000-e257-f686-6aa7" collective="true" subType="mount">
@@ -4390,6 +4559,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sisters Of The Thorn" hidden="false" id="7424-2365-3deb-fb13">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="891d-d0ae-26e6-a665"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="891d-d0ae-26e6-a665">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Sisters Of The Thorn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="a2d0-bf1c-5d70-a11">
           <characteristics>
@@ -4595,6 +4783,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </constraints>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Wild Riders" hidden="false" id="3f3d-ccd8-ad95-1750">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="3360-b432-5476-14ee"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="3360-b432-5476-14ee">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="11" field="selections" scope="self" childId="600c-7d08-5be1-fe0c" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Wild Riders" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="34b9-42a6-1789-15d0">
           <characteristics>
@@ -5355,6 +5562,25 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Guardians of Talsyn" hidden="false" id="873e-530a-12f0-b908">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="9735-c4b9-04f6-69ec"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="9735-c4b9-04f6-69ec">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Guardians of Talsyn" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="5238-2b67-0ae6-00a3">
           <characteristics>
@@ -5503,6 +5729,39 @@ If this test is failed, only rolls of natural 6 will hit.</characteristic>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Wood Elf Beast Packs" hidden="false" id="806b-f97c-3a1c-28e2">
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="parent" shared="true" id="165b-ed20-8d39-db30"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="0" field="165b-ed20-8d39-db30">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="165b-ed20-8d39-db30">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+            <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="append" value="(exceeds max Unit Strength 20)" field="name">
+          <comment>Battle March: maximum unit strength 20</comment>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="e40a-36c4-0c66-472a" shared="true"/>
+          </conditions>
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="f3f7-ca43-674e-115f" shared="true" includeChildSelections="true"/>
+                <condition type="atLeast" value="21" field="selections" scope="self" childId="19f9-8dd8-bba4-625b" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
       <profiles>
         <profile name="Wood Elf Beast Packs" typeId="2878-9a1f-dd74-48e3" typeName="Unit" hidden="false" id="de68-1576-b1d5-8c4b">
           <characteristics>


### PR DESCRIPTION
Battle March introduced a rule that no unit may exceed unit strength 20, which was previously unenforced. This adds a validation error (it does not clamp any model-count inputs) when a unit's combined unit strength exceeds 20, expressed as per-troop-type model-count thresholds:

Regular Infantry, Heavy Infantry, War Beasts → error above 20 models Light Cavalry, Heavy Cavalry → error above 10 models Monstrous Infantry, Swarms, Light Chariots → error above 6 models Other troop types (Heavy Chariots, Monstrous Creatures, Behemoths, War Machines) and characters can't exceed US 20, so they get nothing.

Each affected unit entry receives an inert max constraint (-1 = unlimited) plus a modifier that sets it to 0 only when the unit is inside the 5. Battle March force AND the unit contains more than the allowed number of models of that troop type

To make the resulting error self-explanatory, a second modifier appends (exceeds max Unit Strength 20) to the unit's name under the same conditions (using the repo's existing append-to-name pattern; multi-type units use a single conditionGroup type="or"), so the error reads:

Battle March has 1 selections too many of Ungor Herds (exceeds max Unit Strength 20) (max 0) Normal games are unaffected (constraint stays -1, name unmodified).

fixes #660