### PR TITLE
fix: Tau'ruk may not be a general

### DIFF
--- a/Chaos Dwarfs - Renegades 2.0.cat
+++ b/Chaos Dwarfs - Renegades 2.0.cat
@@ -1521,11 +1521,6 @@ Note that this special rule is not cumulative. In other words, using it more tha
             </entryLink>
           </entryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Command" hidden="false" id="ce9bb895-d947f28b" sortIndex="5">
-              <entryLinks>
-                <entryLink import="true" name="General" hidden="false" id="57cee8c4-aa4388e" type="selectionEntry" targetId="7d76-b1a1-1535-a04c"/>
-              </entryLinks>
-            </selectionEntryGroup>
             <selectionEntryGroup name="Weapons" hidden="false" id="c5c31b0f-3cc57f9d" sortIndex="4" flatten="true">
               <entryLinks>
                 <entryLink name="Darkforged Weapon" id="386e1dd-3883e993" hidden="false" type="selectionEntry" targetId="b1cc-4c50-1d09-b67c" sortIndex="1">

--- a/Chaos Dwarfs.cat
+++ b/Chaos Dwarfs.cat
@@ -1497,11 +1497,6 @@ When rolling To Wound, the target number is the same as the armour value of the
             </entryLink>
           </entryLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Command" hidden="false" id="ce9bb895-d947f28b" sortIndex="5">
-              <entryLinks>
-                <entryLink import="true" name="General" hidden="false" id="57cee8c4-aa4388e" type="selectionEntry" targetId="7d76-b1a1-1535-a04c"/>
-              </entryLinks>
-            </selectionEntryGroup>
             <selectionEntryGroup name="Weapons" hidden="false" id="c5c31b0f-3cc57f9d" sortIndex="4" flatten="true">
               <entryLinks>
                 <entryLink name="Darkforged Weapon" id="386e1dd-3883e993" hidden="false" type="selectionEntry" targetId="b1cc-4c50-1d09-b67c" sortIndex="1">


### PR DESCRIPTION
Tau'ruk has the loner special rule. Thus it may not be the General of an army. Yet, it still had the General link.

Removing it resolves this issue.

fixes #605