### PR TITLE
fix: Tau'ruk may not be a general- #689

### DIFF
--- a/Chaos Dwarfs - Renegades 2.0.json
+++ b/Chaos Dwarfs - Renegades 2.0.json
@@ -5459,22 +5459,6 @@
               {
                 "entryLinks": [
                   {
-                    "import": true,
-                    "name": "General",
-                    "hidden": false,
-                    "id": "57cee8c4-aa4388e",
-                    "type": "selectionEntry",
-                    "targetId": "7d76-b1a1-1535-a04c"
-                  }
-                ],
-                "name": "Command",
-                "hidden": false,
-                "id": "ce9bb895-d947f28b",
-                "sortIndex": 5
-              },
-              {
-                "entryLinks": [
-                  {
                     "costs": [
                       {
                         "name": "pts",

--- a/Chaos Dwarfs.json
+++ b/Chaos Dwarfs.json
@@ -5256,22 +5256,6 @@
               {
                 "entryLinks": [
                   {
-                    "import": true,
-                    "name": "General",
-                    "hidden": false,
-                    "id": "57cee8c4-aa4388e",
-                    "type": "selectionEntry",
-                    "targetId": "7d76-b1a1-1535-a04c"
-                  }
-                ],
-                "name": "Command",
-                "hidden": false,
-                "id": "ce9bb895-d947f28b",
-                "sortIndex": 5
-              },
-              {
-                "entryLinks": [
-                  {
                     "costs": [
                       {
                         "name": "pts",


### PR DESCRIPTION
Tau'ruk has the loner special rule. Thus it may not be the General of an army. Yet, it still had the General link.

Removing it resolves this issue.

fixes #605