### PR TITLE
Add missing Battle March 'per 1000 points' slot category to 29 catalo…

### DIFF
--- a/Beastmen Brayherds - Minotaur Blood Herd.json
+++ b/Beastmen Brayherds - Minotaur Blood Herd.json
@@ -598,6 +598,14 @@
             "id": "9fd3-ded5-2a41-7f63",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e446-3626-3a48-bb48",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -1196,6 +1204,14 @@
             "id": "210b-ed17-c3b9-f59a",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "38e8-2813-d002-80c6",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -6444,6 +6460,14 @@
             "id": "deaa-2e91-4668-c76b",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "72f3-c8f7-559b-fec1",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -10604,6 +10628,14 @@
             "id": "7871-f749-b8ff-e33c",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Minotaur Blood Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "6edc-354d-57dd-dfc0",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -12418,7 +12450,7 @@
     "name": "Beastmen Brayherds - Minotaur Blood Herd",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 144,
-    "revision": 12,
+    "revision": 13,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Beastmen Breyherds - Wild Herd.json
+++ b/Beastmen Breyherds - Wild Herd.json
@@ -28,6 +28,14 @@
             "id": "f1e4-04bf-f7cc-df23",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c782-392f-d3dd-c5a1",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -478,6 +486,14 @@
             "id": "1918-63b6-56aa-938f",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "dfba-5850-8190-b56a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1525,6 +1541,14 @@
             "id": "9ac5-7031-c903-96db",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "09b3-eac0-7b07-f16d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -4198,6 +4222,14 @@
             "id": "c6e2-63b5-8aca-7f65",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3cee-2d8e-59ba-ab19",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Core",
@@ -12185,6 +12217,14 @@
             "id": "9219-9f49-8dd7-dac1",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3cee-2d8e-59ba-ab19",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12641,6 +12681,14 @@
             "id": "3ded-9c8e-310b-16a1",
             "primary": false,
             "name": "Faction: Beastmen Brayherds - Wild Herd"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3cee-2d8e-59ba-ab19",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -16996,7 +17044,7 @@
     "name": "Beastmen Brayherds - Wild Herd",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 144,
-    "revision": 16,
+    "revision": 17,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Bretonnian Exiles.json
+++ b/Bretonnian Exiles.json
@@ -29,6 +29,14 @@
             "id": "a994-68e4-52b1-cd0c",
             "primary": false,
             "targetId": "c796-bbb0-377c-76b1"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e2a3-685e-8fb6-fb04",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7157,6 +7165,14 @@
             "id": "8e70-d1f3-4779-1c04",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d55c-9f5a-75c1-bddf",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -8970,6 +8986,14 @@
             "id": "7c8f-d786-d116-a2b2",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "1658-6866-9177-52e2",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -9569,6 +9593,14 @@
             "id": "ae5e-1fc2-5156-1d88",
             "primary": false,
             "targetId": "c796-bbb0-377c-76b1"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "30ee-c453-2bb1-72eb",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -13521,7 +13553,7 @@
     "name": "Kingdom of Bretonnia - Bretonnian Exiles",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 77,
-    "revision": 24,
+    "revision": 25,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Chaos Dwarfs - Renegades 2.0.json
+++ b/Chaos Dwarfs - Renegades 2.0.json
@@ -22579,6 +22579,14 @@
             "id": "72b3-7b18-4e52-e943",
             "targetId": "4344-b118-fe89-972a",
             "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "74b5-93aa-467f-f841",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -32013,7 +32021,7 @@
     "name": "Chaos Dwarfs - Renegades 2.0",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 49,
-    "revision": 3,
+    "revision": 4,
     "battleScribeVersion": 2.03,
     "type": "catalogue",
     "xmlns": "http://www.battlescribe.net/schema/catalogueSchema",

--- a/Chaos Dwarfs.json
+++ b/Chaos Dwarfs.json
@@ -23216,6 +23216,14 @@
             "id": "6393-fc30-7d04-f629",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9bc5-bd07-204b-9106",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -24880,6 +24888,14 @@
             "id": "1d29-06f0-1057-d9fd",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "2b1f-b8f0-4c22-5914",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -28411,7 +28427,7 @@
     "name": "Chaos Dwarfs",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 49,
-    "revision": 67,
+    "revision": 68,
     "battleScribeVersion": 2.03,
     "type": "catalogue",
     "xmlns": "http://www.battlescribe.net/schema/catalogueSchema",

--- a/Dwarfen Mountain Holds - Expeditionary Force.json
+++ b/Dwarfen Mountain Holds - Expeditionary Force.json
@@ -9176,6 +9176,14 @@
             "id": "0f54-a1b9-5372-6731",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "19ec-ccfd-224e-3e63",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -9790,6 +9798,14 @@
             "id": "a470-906f-9389-397a",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "4ad5-0ca2-d466-94c5",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -10404,6 +10420,14 @@
             "id": "3733-3ace-b1b9-c3f9",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "f04c-993c-b312-9f7e",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -11463,6 +11487,14 @@
             "id": "9902-4b9f-d922-2cd4",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "889a-22c6-9d3f-271a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12067,6 +12099,14 @@
             "id": "9329-aab5-5319-e697",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "0f76-1163-1b9d-8115",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -13268,6 +13308,14 @@
             "id": "9d05-3406-cc17-7d44",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "cfa0-e0df-d5cb-b24b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -13890,6 +13938,14 @@
             "id": "2aa9-1e64-5edc-c57b",
             "primary": true,
             "name": "Mercenaries"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "fd57-6107-a450-ef3d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -14896,7 +14952,7 @@
     "name": "Dwarfen Mountain Holds - Expeditionary Force",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 118,
-    "revision": 12,
+    "revision": 13,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "discord: Tidomann",
     "authorName": "Tidomann",

--- a/Dwarfen Mountain Holds - Royal Clan.json
+++ b/Dwarfen Mountain Holds - Royal Clan.json
@@ -2186,6 +2186,14 @@
             "id": "0a1d-5389-a69b-6239",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "b47d-56d2-d42f-2d37",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -2790,6 +2798,14 @@
             "id": "91cc-1ed7-d13a-2d53",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c1c1-e502-8fc7-799a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -6934,6 +6950,14 @@
             "id": "378b-d5ca-a2b9-08a8",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "1282-b908-31f0-edbf",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7538,6 +7562,14 @@
             "id": "a9bc-a461-774c-637d",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d9c4-3358-d761-7768",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -10820,6 +10852,14 @@
             "id": "b16a-b0fb-1296-959b",
             "primary": true,
             "name": "Mercenaries"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "a01f-a544-f2e6-0bc6",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12618,6 +12658,14 @@
             "id": "b478-05d1-d870-eba9",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "8b21-6c9e-3744-f196",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -13229,6 +13277,14 @@
             "id": "e78f-8ddb-b303-1755",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9b38-37be-c0df-c54a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Special Ungrim General",
@@ -13834,7 +13890,7 @@
     "name": "Dwarfen Mountain Holds - Royal Clan",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 117,
-    "revision": 11,
+    "revision": 12,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Dwarfen Mountain Holds - Slayer Host.json
+++ b/Dwarfen Mountain Holds - Slayer Host.json
@@ -460,6 +460,14 @@
             "id": "f8dc-3733-2813-b97d",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3903-b666-24f1-370a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -2585,6 +2593,14 @@
             "id": "956a-0ee7-82ab-4855",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "8864-2daa-ac23-690e",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -3180,6 +3196,14 @@
             "id": "ef3b-4253-f9c8-5546",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "a1db-1c8f-9296-abb5",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -5143,7 +5167,7 @@
     "name": "Dwarfen Mountain Holds - Slayer Host",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 152,
-    "revision": 12,
+    "revision": 13,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Grand Cathay - Jade Fleet.json
+++ b/Grand Cathay - Jade Fleet.json
@@ -484,6 +484,14 @@
             "id": "c5e6-d36c-f81d-d670",
             "primary": false,
             "name": "0-1 Shugengan Lord or Lord Magistrate per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d1de-5056-f4e3-e8a9",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7187,6 +7195,14 @@
             "id": "c2ba-0510-7e83-bc69",
             "primary": false,
             "name": "0-1 Captain of the Empire, Master Mage, Priest of Sigmar or Priest of Ulric per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "230d-c890-7951-d523",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7631,6 +7647,14 @@
             "id": "fb34-ac9a-0c0b-7921",
             "primary": false,
             "name": "0-1 Captain of the Empire, Master Mage, Priest of Sigmar or Priest of Ulric per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e18d-c4bf-cfb2-ee08",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8075,6 +8099,14 @@
             "id": "ffda-033e-9f97-0542",
             "primary": false,
             "name": "0-1 Captain of the Empire, Master Mage, Priest of Sigmar or Priest of Ulric per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3046-d540-5b3b-9da7",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8519,6 +8551,14 @@
             "id": "996c-e9fc-9fac-ada0",
             "primary": false,
             "name": "0-1 Captain of the Empire, Master Mage, Priest of Sigmar or Priest of Ulric per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "2eaa-d246-e212-4f6b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11333,6 +11373,14 @@
             "id": "770c-dbff-2354-fbb7",
             "primary": false,
             "name": "0-1 Shugengan Lord or Lord Magistrate per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "eeb6-2377-e0fe-a51d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11783,6 +11831,14 @@
             "id": "6e31-8507-b179-7820",
             "primary": false,
             "name": "0-1 unit of Pistoliers or Outriders per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "36af-c65e-443f-db08",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12233,6 +12289,14 @@
             "id": "3286-3d06-5667-9cda",
             "primary": false,
             "name": "0-1 unit of Pistoliers or Outriders per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "30d3-27e0-8fe8-de40",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [

--- a/Grand Cathay - Warriors of Wind & Field.json
+++ b/Grand Cathay - Warriors of Wind & Field.json
@@ -2974,6 +2974,14 @@
             "id": "1985-0126-d4e3-eae8",
             "primary": false,
             "name": "0-1 Lord Magistrate, Gate Master, or Supreme Astromancer per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "613d-c6d6-09e8-a175",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -2996,6 +3004,14 @@
             "id": "f72a-bf2e-ddac-8930",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9574-4ab1-c921-72fd",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -3862,6 +3878,14 @@
             "id": "1c1f-3a18-b3b2-3359",
             "primary": false,
             "name": "0-1 Lord Magistrate, Gate Master, or Supreme Astromancer per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "eae3-0e3b-fbae-f31e",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -5650,6 +5674,14 @@
             "id": "71a2-2efe-85b8-d7a5",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "10e8-7bb0-c3a3-8f61",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Core",
@@ -7447,6 +7479,14 @@
             "id": "587e-0a9e-c83b-6014",
             "primary": false,
             "name": "0-2 Fire Rain Rocket Batteries or Cathayan Grand Cannon per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "b45a-8ea2-cb0e-d5e5",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7891,6 +7931,14 @@
             "id": "cd5f-816b-0ada-6fd5",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "009f-0775-810d-451d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -9966,7 +10014,7 @@
     "name": "Grand Cathay - Warriors of Wind & Field",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 164,
-    "revision": 11,
+    "revision": 12,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/High Elf Realms - Chracian Warhost.json
+++ b/High Elf Realms - Chracian Warhost.json
@@ -1094,6 +1094,14 @@
             "id": "23e8-b3e7-e68f-8094",
             "primary": true,
             "name": "Characters"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7de0-a3bb-67d8-c5f3",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1544,6 +1552,14 @@
             "id": "8f48-341c-5a5a-c7b3",
             "primary": false,
             "name": "0-1 High Elf Prince or Archmage per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "03b9-0856-cf4d-950c",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1994,6 +2010,14 @@
             "id": "8d78-82a6-d305-f740",
             "primary": false,
             "name": "Faction: High Elf Realms - Chracian Warhost"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "6fed-2dec-5647-4197",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -4235,6 +4259,14 @@
             "id": "6463-19a6-7f15-631d",
             "primary": false,
             "name": "Faction: High Elf Realms - Chracian Warhost"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "94fa-985b-0b6f-ac83",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Core",
@@ -6029,6 +6061,14 @@
             "id": "2eff-a7fd-1e9e-94e6",
             "primary": true,
             "name": "Special"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d5d8-714c-08b4-873d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7098,6 +7138,14 @@
             "id": "ba41-b8e7-5db4-9605",
             "primary": false,
             "name": "0-1 unit of Shadow Warriors or Sisters of Avelorn per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "1aa1-8603-7ee4-57d9",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7554,6 +7602,14 @@
             "id": "fbc8-a11d-bd76-06cc",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3783-17d5-e7ae-0bc1",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8012,6 +8068,14 @@
             "id": "dbdd-cab5-48c0-939e",
             "primary": true,
             "name": "Rare"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d9ee-288c-9df7-6cac",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8462,6 +8526,14 @@
             "id": "26b9-bd0e-47ce-3a74",
             "primary": false,
             "name": "0-1 Eagle Claw Bolt Throwers per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c7c0-c801-d436-e5ea",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -9841,7 +9913,7 @@
     "name": "High Elf Realms - Chracian Warhost",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 120,
-    "revision": 15,
+    "revision": 16,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/High Elf Realms - Sea Guard Garrison.json
+++ b/High Elf Realms - Sea Guard Garrison.json
@@ -1210,6 +1210,14 @@
             "id": "5b7e-107f-0874-42e0",
             "primary": false,
             "name": "0-1 Dragon Mage, High Elf Noble, or High Elf Mage per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "ab0a-b504-eab2-735a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1660,6 +1668,14 @@
             "id": "0d84-bc5b-f632-8c0b",
             "primary": false,
             "name": "Faction: High Elf Realms - Sea Guard Garrison"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "2af1-1e52-e5fb-622e",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -2110,6 +2126,14 @@
             "id": "9f36-2fdb-e49c-d777",
             "primary": false,
             "name": "Faction: High Elf Realms - Sea Guard Garrison"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "aab5-14e0-201f-8631",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -3163,6 +3187,14 @@
             "id": "c9b3-274f-f6fa-d91e",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "b46d-ceed-9914-47b3",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -4372,6 +4404,14 @@
             "id": "dd02-584d-89d1-6aca",
             "primary": false,
             "name": "Faction: High Elf Realms - Sea Guard Garrison"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "0d75-7494-584b-88d4",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -4822,6 +4862,14 @@
             "id": "8f86-2589-1529-d48d",
             "primary": false,
             "name": "0-3 Eagle Claw Bolt Throwers per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "26b9-8afe-fbf1-dd23",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -5878,6 +5926,14 @@
             "id": "81bc-cf66-0176-ebd8",
             "primary": false,
             "name": "Faction: High Elf Realms - Sea Guard Garrison"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "ef89-d333-b8ad-12f2",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -6337,6 +6393,14 @@
             "id": "a54f-086a-576e-44be",
             "primary": false,
             "name": "Faction: High Elf Realms - Sea Guard Garrison"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c822-546a-2d2d-7728",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8755,7 +8819,7 @@
     "name": "High Elf Realms - Sea Guard Garrison",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 120,
-    "revision": 13,
+    "revision": 14,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/High Elf Realms.json
+++ b/High Elf Realms.json
@@ -42950,6 +42950,14 @@
             "id": "0e09-c8ff-a2d2-b024",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "426f-443c-ae50-573a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -48213,7 +48221,7 @@
     "name": "High Elf Realms",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 22,
-    "revision": 126,
+    "revision": 127,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Kingdom of Bretonnia - Errantry Crusade.json
+++ b/Kingdom of Bretonnia - Errantry Crusade.json
@@ -485,6 +485,14 @@
             "id": "cfe0-9072-51d7-cb01",
             "primary": false,
             "targetId": "6acb-f99a-8d48-1c3d"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3b9e-5805-a320-4357",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1115,6 +1123,14 @@
             "id": "ee3d-9a24-5327-3100",
             "primary": false,
             "targetId": "6acb-f99a-8d48-1c3d"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c1c9-3b1f-56fc-5262",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -13810,7 +13826,7 @@
     "name": "Kingdom of Bretonnia - Errantry Crusade",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 78,
-    "revision": 18,
+    "revision": 19,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Lizardmen - Renegades v2.json
+++ b/Lizardmen - Renegades v2.json
@@ -13501,6 +13501,14 @@
             "id": "new-slann-cat",
             "targetId": "26e8-5eab-2e75-782f",
             "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d507-56f3-bd36-3dda",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -25725,6 +25733,14 @@
             "id": "66e2-959a-be55-8b5a",
             "targetId": "a4cc-15c9-cfae-1b3b",
             "primary": true
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "19d9-2e6e-df66-9b93",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -35253,7 +35269,7 @@
     "name": "Lizardmen - Renegades 2.0",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 49,
-    "revision": 1,
+    "revision": 2,
     "battleScribeVersion": 2.03,
     "type": "catalogue",
     "xmlns": "http://www.battlescribe.net/schema/catalogueSchema",

--- a/Lizardmen.json
+++ b/Lizardmen.json
@@ -24731,6 +24731,14 @@
             "id": "66e2-959a-be55-8b5a",
             "targetId": "a4cc-15c9-cfae-1b3b",
             "primary": true
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "edf4-628a-dc10-cb59",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -33950,7 +33958,7 @@
     "name": "Lizardmen",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 49,
-    "revision": 65,
+    "revision": 66,
     "battleScribeVersion": 2.03,
     "type": "catalogue",
     "authorContact": "Giloushaker#2496"

--- a/Orc and Goblin Tribes - Nomadic Waagh!.json
+++ b/Orc and Goblin Tribes - Nomadic Waagh!.json
@@ -930,6 +930,14 @@
             "id": "3ab9-4655-c68f-c05a",
             "primary": false,
             "targetId": "f89b-a1c3-e6eb-e69a"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "288f-8b72-6033-e9c8",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1551,6 +1559,14 @@
             "id": "40ae-d39c-5cb-c2cc",
             "primary": false,
             "targetId": "f89b-a1c3-e6eb-e69a"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "6e27-9048-39f5-372b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11940,7 +11956,7 @@
     "name": "Orc and Goblin Tribes - Nomadic Waaagh!",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 98,
-    "revision": 21,
+    "revision": 22,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Orc and Goblin Tribes - Troll Horde.json
+++ b/Orc and Goblin Tribes - Troll Horde.json
@@ -16,6 +16,14 @@
             "id": "bdc4-d35a-db38-d9",
             "primary": false,
             "targetId": "f812-7780-6897-718b"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "4d67-7b23-d027-0074",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -637,6 +645,14 @@
             "id": "dc1f-f6cf-67c2-5bae",
             "primary": false,
             "targetId": "f812-7780-6897-718b"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c28b-1527-cff4-84a4",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12704,6 +12720,14 @@
             "id": "153c-ab37-4a03-db9d",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "5e05-7d0a-58b7-10a9",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -13310,6 +13334,14 @@
             "id": "8059-75e9-a4b6-6e98",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7105-1d65-1775-ec2c",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -15432,7 +15464,7 @@
     "name": "Orc and Goblin Tribes - Troll Horde",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 98,
-    "revision": 16,
+    "revision": 17,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Renegade Crowns.json
+++ b/Renegade Crowns.json
@@ -13157,6 +13157,14 @@
             "id": "81a9-ed31-b487-4066",
             "primary": false,
             "name": "0-1 Border Princes Organ Gun or Border Princes Bombard per 1,000 Points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "332a-77fa-85c7-9915",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -18037,7 +18045,7 @@
     "name": "Realms of Man - Renegade Crowns",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 152,
-    "revision": 17,
+    "revision": 18,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Skaven.json
+++ b/Skaven.json
@@ -26131,6 +26131,14 @@
             "id": "6871-51a7-4628-0cd0",
             "targetId": "a4cc-15c9-cfae-1b3b",
             "primary": true
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7493-20db-b4ad-c2c8",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "No Warhall",
@@ -26746,6 +26754,14 @@
             "id": "4b67-79f4-23d3-24ab",
             "targetId": "a4cc-15c9-cfae-1b3b",
             "primary": true
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9cf8-8d4d-9cd2-7111",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "No Warhall",
@@ -34193,7 +34209,7 @@
     "name": "Skaven",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 49,
-    "revision": 72,
+    "revision": 73,
     "battleScribeVersion": 2.03,
     "type": "catalogue",
     "authorContact": "Giloushaker#2496"

--- a/The Empire of Man - City-State of Nuln.json
+++ b/The Empire of Man - City-State of Nuln.json
@@ -6276,6 +6276,14 @@
             "id": "d059-2183-2e30-db7c",
             "primary": false,
             "name": "Faction: The Empire of Man - City-state of Nuln"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "4e1b-864a-e111-7e47",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Core",
@@ -12784,6 +12792,14 @@
             "id": "3180-864d-daf4-4d91",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e86d-d364-1c22-564a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -14561,6 +14577,14 @@
             "id": "c9b0-dd07-b306-50a5",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e28f-671c-aa67-e76c",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -15480,7 +15504,7 @@
     "name": "The Empire of Man - City-State of Nuln",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 127,
-    "revision": 17,
+    "revision": 18,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/The Empire of Man - Knightly Order.json
+++ b/The Empire of Man - Knightly Order.json
@@ -8116,6 +8116,14 @@
             "id": "1ef0-2016-7a53-13ca",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "6de6-8609-d8c2-4f05",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -8717,6 +8725,14 @@
             "id": "59f9-443f-42e3-0ab7",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "b3ae-dec1-a421-179b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11199,6 +11215,14 @@
             "id": "5901-bd0e-2602-a9d9",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "cda0-bcaa-74eb-0fe7",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11257,6 +11281,14 @@
             "id": "c072-9948-1459-4506",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "865a-e395-d1e3-e30b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -18671,7 +18703,7 @@
     "name": "The Empire of Man - Knightly Order",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 127,
-    "revision": 16,
+    "revision": 17,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Tomb Kings - Mortuary Cult.json
+++ b/Tomb Kings - Mortuary Cult.json
@@ -1256,6 +1256,14 @@
             "id": "cbac-0721-d2a8-5e37",
             "primary": false,
             "name": "0-1 Tomb Prince or Arch Necrotect per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "20d5-b2be-15ad-f096",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -13049,6 +13057,14 @@
             "id": "a4c6-6463-1e1e-ca29",
             "primary": false,
             "targetId": "22ae-234f-ffd2-6c4f"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "1af8-3b40-a283-b648",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -13647,6 +13663,14 @@
             "id": "1ce3-1ef3-36a-b192",
             "primary": false,
             "targetId": "22ae-234f-ffd2-6c4f"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7088-0202-9a54-6806",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -14258,6 +14282,14 @@
             "id": "a1c6-bb3c-38e4-171d",
             "primary": false,
             "name": "0-1 Tomb Prince or Arch Necrotect per 1,000 points"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9486-59de-fef2-90d1",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -15906,6 +15938,14 @@
             "id": "73eb-2f8d-12a4-dbbc",
             "targetId": "fec1-537a-bbeb-7926",
             "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "304c-a824-df26-fc0d",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -16676,7 +16716,7 @@
     "name": "Tomb Kings of Khemri - Mortuary Cult",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 79,
-    "revision": 25,
+    "revision": 26,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Tomb Kings - Nehekharan Royal Host.json
+++ b/Tomb Kings - Nehekharan Royal Host.json
@@ -9448,6 +9448,14 @@
             "id": "927a-25eb-ab5a-18b6",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "23f9-2de6-d29a-2dc5",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -10054,6 +10062,14 @@
             "id": "7e53-4f1a-55b5-c645",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "6760-1fa0-65aa-8353",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -10653,6 +10669,14 @@
             "id": "cedf-5719-1d9e-fc74",
             "primary": false,
             "targetId": "fdc8-bc34-f83d-4833"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "ccf9-71e2-480d-a791",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12687,7 +12711,7 @@
     "name": "Tomb Kings of Khemri - Royal Host",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 79,
-    "revision": 24,
+    "revision": 25,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Warriors of Chaos - Heralds of Darkness.json
+++ b/Warriors of Chaos - Heralds of Darkness.json
@@ -11053,6 +11053,14 @@
             "id": "51b7-faf2-d3dc-82d2",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Heralds of Darkness"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "c05b-2251-5a54-2d18",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11655,6 +11663,14 @@
             "id": "6958-bf17-b270-ced3",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Heralds of Darkness"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "a51a-ea39-155d-aeee",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -14386,7 +14402,7 @@
     "name": "Warriors of Chaos - Heralds of Darkness",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 119,
-    "revision": 14,
+    "revision": 15,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Warriors of Chaos - Hordes of Chaos.json
+++ b/Warriors of Chaos - Hordes of Chaos.json
@@ -1528,6 +1528,14 @@
             "id": "3a0a-a8b0-9d27-5069",
             "targetId": "e703-b018-49f4-3f24",
             "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "b706-ad18-0bb4-f098",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1999,6 +2007,14 @@
             "id": "4435-d5c5-c16b-8d2f",
             "targetId": "e703-b018-49f4-3f24",
             "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "0f1d-6f83-d784-e9d6",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -2451,6 +2467,14 @@
             "hidden": false,
             "id": "493a-7b20-0503-517b",
             "targetId": "e703-b018-49f4-3f24",
+            "primary": false
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "3665-0167-4e2c-3884",
+            "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
         ],
@@ -17631,7 +17655,7 @@
     "name": "Warriors of Chaos - Hordes of Chaos",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 181,
-    "revision": 1,
+    "revision": 2,
     "authorName": "Flammy",
     "authorContact": "Discord: vflam",
     "authorUrl": "www.newrecruit.eu",

--- a/Warriors of Chaos - Wolves of the Sea.json
+++ b/Warriors of Chaos - Wolves of the Sea.json
@@ -11546,6 +11546,14 @@
             "id": "3e8d-8fad-a0c1-cf01",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Wolves of the Sea"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "aa88-27f2-8baf-1edc",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12616,6 +12624,14 @@
             "id": "b904-eb81-3551-93d9",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Wolves of the Sea"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "5722-3cc2-19d8-62d8",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -14598,7 +14614,7 @@
     "name": "Warriors of Chaos - Wolves of the Sea",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 119,
-    "revision": 11,
+    "revision": 12,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Wood Elf Realms - Host of Talsyn.json
+++ b/Wood Elf Realms - Host of Talsyn.json
@@ -42,6 +42,14 @@
             "id": "c66e-8b2e-d9b5-20cc",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "4eae-02eb-015b-d284",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -492,6 +500,14 @@
             "id": "7d38-4789-6146-1a2f",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "0c5f-d6e4-9fe2-7e3b",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -936,6 +952,14 @@
             "id": "9327-e03b-4854-126d",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e4cb-c74d-19aa-58b2",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -4841,6 +4865,14 @@
             "id": "4c5f-ddbd-4b72-b0cb",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "2a3d-4d48-8212-679c",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -7067,6 +7099,14 @@
             "id": "ea58-b64d-55c1-6f8e",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "a4b2-b0d5-89f5-4be0",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -9943,6 +9983,14 @@
             "id": "e341-2337-2aa0-0bb3",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7737-7163-bc72-cb45",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -11738,6 +11786,14 @@
             "id": "f93f-0c8f-3d94-6602",
             "primary": false,
             "name": "Faction: Wood Elf Realms - Host of Talsyn"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d16e-8b8c-f85a-09ce",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -12326,7 +12382,7 @@
     "name": "Wood Elf Realms - Host of Talsyn",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 142,
-    "revision": 9,
+    "revision": 10,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Wood Elf Realms.json
+++ b/Wood Elf Realms.json
@@ -33364,6 +33364,14 @@
             "id": "ed45-ee71-355b-d9c8",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "4bbb-5b35-7cc0-793c",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "comment": "Core",
@@ -37321,7 +37329,7 @@
     "name": "Wood Elf Realms",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 22,
-    "revision": 110,
+    "revision": 111,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",


### PR DESCRIPTION
…gues

standing on the shoulder of giants:
https://github.com/vflam/Warhammer-The-Old-World/commit/520e1a86f0bc1ef5454d9c84e4b5dea390b689cb

Entries limited to 0-X per 1,000 points (via paired categories or force-scoped max constraints) were missing the hidden "1 single 'per 1000 points' selection in Battle March" category, so they never consumed the single Battle March slot. Added it to 108 entry links across 29 catalogues, following the pattern from 520e1a8.

Mandatory per-1,000 minimums (e.g. Troll Mobs, Minotaur Herds) and Combined Arms-only limits are deliberately excluded. Each changed catalogue's revision is bumped to invalidate cached copies.