### PR TITLE
fix: add missing 0-1 restriction for Warriors of Chaos & Empire

### DIFF
--- a/The Empire of Man - City-State of Nuln.json
+++ b/The Empire of Man - City-State of Nuln.json
@@ -648,6 +648,14 @@
             "id": "a6fb-1a36-4c1e-b793",
             "primary": false,
             "name": "General of the Empire or Lector of Sigmar"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e86d-d364-1c22-564a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -1098,12 +1106,6 @@
             "id": "77cf-bc0f-744d-e921",
             "primary": true,
             "name": "Named Characters"
-          },
-          {
-            "targetId": "7b2a-cc3e-5fc8-a8fe",
-            "id": "a4e6-8889-0161-d4af",
-            "primary": false,
-            "name": "General of the Empire or Lector of Sigmar"
           },
           {
             "name": "Commander of the Empire",
@@ -4510,6 +4512,20 @@
             "id": "5656-8aa1-1cff-b372",
             "primary": false,
             "name": "Faction: The Empire of Man - City-state of Nuln"
+          },
+          {
+            "targetId": "7b2a-cc3e-5fc8-a8fe",
+            "id": "a6fb-1a36-4c1e-b793",
+            "primary": false,
+            "name": "General of the Empire or Lector of Sigmar"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e86d-d364-1c22-564a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [

--- a/The Empire of Man - City-State of Nuln.json
+++ b/The Empire of Man - City-State of Nuln.json
@@ -653,7 +653,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e86d-d364-1c22-564a",
+            "id": "c528-9f13-a674-e0db",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -12813,7 +12813,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e86d-d364-1c22-564a",
+            "id": "81de-3a56-f9c2-47b8",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -15520,7 +15520,7 @@
     "name": "The Empire of Man - City-State of Nuln",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 127,
-    "revision": 18,
+    "revision": 19,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/The Empire of Man - City-State of Nuln.json
+++ b/The Empire of Man - City-State of Nuln.json
@@ -653,7 +653,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "c528-9f13-a674-e0db",
+            "id": "81de-3a56-f9c2-47b8",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -4523,7 +4523,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e86d-d364-1c22-564a",
+            "id": "4a76-e285-3c91-bd60",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -12813,7 +12813,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "81de-3a56-f9c2-47b8",
+            "id": "e86d-d364-1c22-564a",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }

--- a/The Empire of Man - Knightly Order.json
+++ b/The Empire of Man - Knightly Order.json
@@ -1635,7 +1635,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e86d-d364-1c22-564a",
+            "id": "e704-52bd-1a89-cf36",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -2315,7 +2315,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e86d-d364-1c22-564a",
+            "id": "6f29-c843-75ae-b102",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -18773,7 +18773,7 @@
     "name": "The Empire of Man - Knightly Order",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 127,
-    "revision": 19,
+    "revision": 20,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/The Empire of Man - Knightly Order.json
+++ b/The Empire of Man - Knightly Order.json
@@ -1630,6 +1630,14 @@
             "id": "2c0d-f9cb-2015-7355",
             "primary": false,
             "name": "Lector or High Priest"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e86d-d364-1c22-564a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -2302,6 +2310,14 @@
             "id": "1b4d-eb73-c2f9-db93",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e86d-d364-1c22-564a",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -11215,14 +11231,6 @@
             "id": "5901-bd0e-2602-a9d9",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
-          },
-          {
-            "comment": "Battle March Category",
-            "name": "1 single 'per 1000 points' selection in Battle March",
-            "hidden": true,
-            "id": "cda0-bcaa-74eb-0fe7",
-            "targetId": "27c9-52f0-c942-681e",
-            "primary": false
           }
         ],
         "constraints": [
@@ -11281,14 +11289,6 @@
             "id": "c072-9948-1459-4506",
             "primary": false,
             "name": "Faction: The Empire of Man - Knightly Order"
-          },
-          {
-            "comment": "Battle March Category",
-            "name": "1 single 'per 1000 points' selection in Battle March",
-            "hidden": true,
-            "id": "865a-e395-d1e3-e30b",
-            "targetId": "27c9-52f0-c942-681e",
-            "primary": false
           }
         ],
         "modifiers": [

--- a/Warriors of Chaos - Heralds of Darkness.json
+++ b/Warriors of Chaos - Heralds of Darkness.json
@@ -1062,6 +1062,14 @@
             "id": "65ab-4bcd-bd21-4bbd",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Heralds of Darkness"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "7b42-e91f-c836-a5d0",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -1576,6 +1584,14 @@
             "id": "702d-57b4-9203-72c9",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Heralds of Darkness"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "d615-4fa9-82ce-b371",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "modifiers": [
@@ -14402,7 +14418,7 @@
     "name": "Warriors of Chaos - Heralds of Darkness",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 119,
-    "revision": 15,
+    "revision": 16,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Warriors of Chaos - Wolves of the Sea.json
+++ b/Warriors of Chaos - Wolves of the Sea.json
@@ -3494,6 +3494,14 @@
             "id": "551c-c593-2b0e-e61b",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Wolves of the Sea"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "2c87-b14e-6d59-f0a3",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -3944,6 +3952,14 @@
             "id": "4708-6dd0-11f8-fafa",
             "primary": false,
             "name": "Faction: Warriors of Chaos - Wolves of the Sea"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "9e31-6bca-d742-18f5",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -14614,7 +14630,7 @@
     "name": "Warriors of Chaos - Wolves of the Sea",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 119,
-    "revision": 12,
+    "revision": 13,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: Tidomann",
     "authorName": "Tidomann",

--- a/Warriors of Chaos.json
+++ b/Warriors of Chaos.json
@@ -35958,6 +35958,14 @@
             "id": "da94-9b9b-0fec-6126",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e446-3626-3a48-bb48",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [

--- a/Warriors of Chaos.json
+++ b/Warriors of Chaos.json
@@ -35216,6 +35216,14 @@
             "id": "63d4-2558-0839-8b8f",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e446-3626-3a48-bb48",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -35958,14 +35966,6 @@
             "id": "da94-9b9b-0fec-6126",
             "primary": false,
             "name": "Units (not including units whose troop type is 'swarms', 'war beasts' or 'war machines')"
-          },
-          {
-            "comment": "Battle March Category",
-            "name": "1 single 'per 1000 points' selection in Battle March",
-            "hidden": true,
-            "id": "e446-3626-3a48-bb48",
-            "targetId": "27c9-52f0-c942-681e",
-            "primary": false
           }
         ],
         "constraints": [

--- a/Warriors of Chaos.json
+++ b/Warriors of Chaos.json
@@ -21728,6 +21728,14 @@
             "id": "0ba8-75d1-6dbc-9b1e",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e446-3626-3a48-bb48",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "import": true,
@@ -32743,6 +32751,14 @@
             "id": "5dd6-b871-4de5-5175",
             "primary": false,
             "targetId": "fec1-537a-bbeb-7926"
+          },
+          {
+            "comment": "Battle March Category",
+            "name": "1 single 'per 1000 points' selection in Battle March",
+            "hidden": true,
+            "id": "e446-3626-3a48-bb48",
+            "targetId": "27c9-52f0-c942-681e",
+            "primary": false
           }
         ],
         "constraints": [
@@ -41253,7 +41269,7 @@
     "name": "Warriors of Chaos",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 22,
-    "revision": 120,
+    "revision": 121,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "Discord: vflam",
     "authorName": "Flammy",

--- a/Warriors of Chaos.json
+++ b/Warriors of Chaos.json
@@ -21733,7 +21733,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e446-3626-3a48-bb48",
+            "id": "a91f-7c3e-b842-d105",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -32756,7 +32756,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e446-3626-3a48-bb48",
+            "id": "5e28-c9a7-31fd-6b44",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }
@@ -35237,7 +35237,7 @@
             "comment": "Battle March Category",
             "name": "1 single 'per 1000 points' selection in Battle March",
             "hidden": true,
-            "id": "e446-3626-3a48-bb48",
+            "id": "f3a8-1d7c-b529-e604",
             "targetId": "27c9-52f0-c942-681e",
             "primary": false
           }


### PR DESCRIPTION
the category was missing for the spawn in Warriors of Chaos 
also for numerous entries in the more specific warriors armies as well as the specific empire armies.

fixes #701