### PR TITLE
fix: Battle march 0-1 per 1000 pts modifier Orcs&Goblins

### DIFF
--- a/Orc and Goblin Tribes.json
+++ b/Orc and Goblin Tribes.json
@@ -2137,14 +2137,6 @@
                         "id": "5513-3a40-4b15-6865",
                         "targetId": "49a9-ce63-af1a-18f7",
                         "primary": false
-                      },
-                      {
-                        "comment": "Battle March Category",
-                        "name": "1 single 'per 1000 points' selection in Battle March",
-                        "hidden": true,
-                        "id": "f07d-a5a6-7c32-3eec",
-                        "targetId": "27c9-52f0-c942-681e",
-                        "primary": false
                       }
                     ],
                     "constraints": [
@@ -3047,14 +3039,6 @@
                         "hidden": false,
                         "id": "b18c-a320-a40c-eb38",
                         "targetId": "49a9-ce63-af1a-18f7",
-                        "primary": false
-                      },
-                      {
-                        "comment": "Battle March Category",
-                        "name": "1 single 'per 1000 points' selection in Battle March",
-                        "hidden": true,
-                        "id": "71d1-1b22-4c38-d282",
-                        "targetId": "27c9-52f0-c942-681e",
                         "primary": false
                       }
                     ],
@@ -5287,14 +5271,6 @@
                         "id": "47ba-fe8-a45c-7a45",
                         "targetId": "49a9-ce63-af1a-18f7",
                         "primary": false
-                      },
-                      {
-                        "comment": "Battle March Category",
-                        "name": "1 single 'per 1000 points' selection in Battle March",
-                        "hidden": true,
-                        "id": "8714-fbaa-4a22-8f41",
-                        "targetId": "27c9-52f0-c942-681e",
-                        "primary": false
                       }
                     ],
                     "constraints": [
@@ -6297,14 +6273,6 @@
                         "id": "d40a-884a-92e1-b0a4",
                         "targetId": "49a9-ce63-af1a-18f7",
                         "primary": false
-                      },
-                      {
-                        "comment": "Battle March Category",
-                        "name": "1 single 'per 1000 points' selection in Battle March",
-                        "hidden": true,
-                        "id": "61f1-8780-c78a-cb96",
-                        "targetId": "27c9-52f0-c942-681e",
-                        "primary": false
                       }
                     ],
                     "constraints": [
@@ -7262,14 +7230,6 @@
                         "hidden": false,
                         "id": "5339-f3b7-4714-b498",
                         "targetId": "49a9-ce63-af1a-18f7",
-                        "primary": false
-                      },
-                      {
-                        "comment": "Battle March Category",
-                        "name": "1 single 'per 1000 points' selection in Battle March",
-                        "hidden": true,
-                        "id": "3381-6228-b037-575b",
-                        "targetId": "27c9-52f0-c942-681e",
                         "primary": false
                       }
                     ],
@@ -21726,16 +21686,7 @@
           }
         ],
         "comment": "Shamans",
-        "categoryLinks": [
-          {
-            "comment": "Battle March Category",
-            "name": "1 single 'per 1000 points' selection in Battle March",
-            "hidden": true,
-            "id": "fe94-c1d5-e61e-e7e5",
-            "targetId": "27c9-52f0-c942-681e",
-            "primary": false
-          }
-        ],
+
         "type": "upgrade",
         "import": true,
         "name": "Frenzy",
@@ -21968,16 +21919,6 @@
           }
         ],
         "comment": "Bosses",
-        "categoryLinks": [
-          {
-            "comment": "Battle March Category",
-            "name": "1 single 'per 1000 points' selection in Battle March",
-            "hidden": true,
-            "id": "7e53-0380-82e5-0446",
-            "targetId": "27c9-52f0-c942-681e",
-            "primary": false
-          }
-        ],
         "type": "upgrade",
         "import": true,
         "name": "Frenzy",

--- a/Orc and Goblin Tribes.json
+++ b/Orc and Goblin Tribes.json
@@ -21686,7 +21686,6 @@
           }
         ],
         "comment": "Shamans",
-
         "type": "upgrade",
         "import": true,
         "name": "Frenzy",

--- a/Orc and Goblin Tribes.json
+++ b/Orc and Goblin Tribes.json
@@ -53279,7 +53279,7 @@
     "name": "Orc and Goblin Tribes",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 19,
-    "revision": 189,
+    "revision": 190,
     "authorName": "Flammy",
     "battleScribeVersion": 2.03,
     "type": "catalogue",


### PR DESCRIPTION
for some reason, the "only one 0-1" rule was applied also to command groups.
Thats just wrong.

fixes #653