### PR TITLE
fix: Bretonnian Barons and Prophetress used legacy restrictions

### DIFF
--- a/Bretonnians.json
+++ b/Bretonnians.json
@@ -11399,7 +11399,7 @@
                     "repeats": 1,
                     "field": "selections",
                     "scope": "force",
-                    "childId": "d629-c87d-c6bf-235d",
+                    "childId": "9c0e-74f0-2dcf-6958",
                     "shared": true,
                     "roundUp": false,
                     "includeChildSelections": true
@@ -11409,7 +11409,7 @@
                     "repeats": 1,
                     "field": "selections",
                     "scope": "force",
-                    "childId": "1a2b-329e-b45e-9aec",
+                    "childId": "aec3-ff9c-e8ae-fe42",
                     "shared": true,
                     "roundUp": false,
                     "includeChildSelections": true
@@ -32584,7 +32584,7 @@
     "name": "Kingdom of Bretonnia",
     "gameSystemId": "sys-31d1-bf57-53ea-ad55",
     "gameSystemRevision": 1,
-    "revision": 166,
+    "revision": 167,
     "authorUrl": "www.newrecruit.eu",
     "authorContact": "newrecruit.eu@gmail.com",
     "authorName": "Flammy",

--- a/Bretonnians.json
+++ b/Bretonnians.json
@@ -21084,6 +21084,13 @@
       {
         "categoryLinks": [
           {
+            "name": "Baron or Prophetess",
+            "hidden": false,
+            "id": "f63b-b168-9e13-49e4",
+            "targetId": "ed6d-58ea-c606-4b99",
+            "primary": false
+          },
+          {
             "name": "Characters",
             "hidden": false,
             "id": "7856-d661-d443-44a8",
@@ -21100,15 +21107,6 @@
           }
         ],
         "constraints": [
-          {
-            "type": "max",
-            "value": 0,
-            "field": "selections",
-            "scope": "force",
-            "shared": true,
-            "id": "7287-5fcc-f10c-3a27",
-            "includeChildSelections": true
-          },
           {
             "comment": "Grand melee",
             "type": "max",
@@ -21136,170 +21134,6 @@
         ],
         "modifiers": [
           {
-            "repeats": [
-              {
-                "value": 1000,
-                "repeats": 1,
-                "field": "limit::points",
-                "scope": "roster",
-                "childId": "any",
-                "shared": true,
-                "roundUp": false
-              }
-            ],
-            "conditionGroups": [
-              {
-                "conditions": [
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "8214-cf48-b1cd-5f5e",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "1ae6-ed95-069e-a390",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "cdbe-ecb9-27cb-fd2b",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "0750-5d17-d708-f990",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "e40a-36c4-0c66-472a",
-                    "shared": true
-                  }
-                ],
-                "type": "or"
-              }
-            ],
-            "type": "increment",
-            "value": 1,
-            "field": "7287-5fcc-f10c-3a27"
-          },
-          {
-            "repeats": [
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "bc3e-5a29-5e1b-323",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              },
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "7510-4cb5-3c40-b87b",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              },
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "e9cb-9a99-6d8-4c04",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              }
-            ],
-            "comment": "Baron or Prophetess",
-            "type": "decrement",
-            "value": 1,
-            "field": "7287-5fcc-f10c-3a27"
-          },
-          {
-            "repeats": [
-              {
-                "value": 1000,
-                "repeats": 1,
-                "field": "points",
-                "scope": "force",
-                "childId": "any",
-                "shared": true,
-                "roundUp": false
-              }
-            ],
-            "conditionGroups": [
-              {
-                "conditions": [
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "8214-cf48-b1cd-5f5e",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "1ae6-ed95-069e-a390",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "cdbe-ecb9-27cb-fd2b",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "0750-5d17-d708-f990",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "e40a-36c4-0c66-472a",
-                    "shared": true
-                  }
-                ],
-                "type": "and"
-              }
-            ],
-            "type": "increment",
-            "value": 1,
-            "field": "7287-5fcc-f10c-3a27"
-          },
-          {
             "comment": "Grand melee",
             "conditionGroups": [
               {
@@ -21692,22 +21526,6 @@
             "type": "increment",
             "value": 1,
             "field": "0040-bc1c-bb8c-6638"
-          },
-          {
-            "comment": "Battle march",
-            "conditions": [
-              {
-                "type": "instanceOf",
-                "value": 1,
-                "field": "selections",
-                "scope": "ancestor",
-                "childId": "e40a-36c4-0c66-472a",
-                "shared": true
-              }
-            ],
-            "type": "floor",
-            "value": 1,
-            "field": "7287-5fcc-f10c-3a27"
           }
         ],
         "import": true,
@@ -22306,6 +22124,13 @@
       {
         "categoryLinks": [
           {
+            "name": "Baron or Prophetess",
+            "hidden": false,
+            "id": "16ff-bd2f-8912-42bc",
+            "targetId": "ed6d-58ea-c606-4b99",
+            "primary": false
+          },
+          {
             "name": "Characters",
             "hidden": false,
             "id": "ee0-5d0b-970b-ba6d",
@@ -22323,170 +22148,6 @@
         ],
         "modifiers": [
           {
-            "repeats": [
-              {
-                "value": 1000,
-                "repeats": 1,
-                "field": "limit::points",
-                "scope": "roster",
-                "childId": "any",
-                "shared": true,
-                "roundUp": false
-              }
-            ],
-            "conditionGroups": [
-              {
-                "conditions": [
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "8214-cf48-b1cd-5f5e",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "1ae6-ed95-069e-a390",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "cdbe-ecb9-27cb-fd2b",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "0750-5d17-d708-f990",
-                    "shared": true
-                  },
-                  {
-                    "type": "instanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "e40a-36c4-0c66-472a",
-                    "shared": true
-                  }
-                ],
-                "type": "or"
-              }
-            ],
-            "type": "increment",
-            "value": 1,
-            "field": "1ff9-3420-9c3a-91d2"
-          },
-          {
-            "repeats": [
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "6b9c-516e-c172-370e",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              },
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "7510-4cb5-3c40-b87b",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              },
-              {
-                "value": 1,
-                "repeats": 1,
-                "field": "selections",
-                "scope": "force",
-                "childId": "e9cb-9a99-6d8-4c04",
-                "shared": true,
-                "roundUp": false,
-                "includeChildSelections": true
-              }
-            ],
-            "comment": "Baron or Prophetess",
-            "type": "decrement",
-            "value": 1,
-            "field": "1ff9-3420-9c3a-91d2"
-          },
-          {
-            "repeats": [
-              {
-                "value": 1000,
-                "repeats": 1,
-                "field": "points",
-                "scope": "force",
-                "childId": "any",
-                "shared": true,
-                "roundUp": false
-              }
-            ],
-            "conditionGroups": [
-              {
-                "conditions": [
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "8214-cf48-b1cd-5f5e",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "1ae6-ed95-069e-a390",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "cdbe-ecb9-27cb-fd2b",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "0750-5d17-d708-f990",
-                    "shared": true
-                  },
-                  {
-                    "type": "notInstanceOf",
-                    "value": 1,
-                    "field": "selections",
-                    "scope": "force",
-                    "childId": "e40a-36c4-0c66-472a",
-                    "shared": true
-                  }
-                ],
-                "type": "and"
-              }
-            ],
-            "type": "increment",
-            "value": 1,
-            "field": "1ff9-3420-9c3a-91d2"
-          },
-          {
             "comment": "Grand melee",
             "conditionGroups": [
               {
@@ -22879,33 +22540,9 @@
             "type": "increment",
             "value": 1,
             "field": "95c4-86b1-fa10-a36f"
-          },
-          {
-            "comment": "Battle march",
-            "conditions": [
-              {
-                "type": "instanceOf",
-                "value": 1,
-                "field": "selections",
-                "scope": "ancestor",
-                "childId": "e40a-36c4-0c66-472a",
-                "shared": true
-              }
-            ],
-            "type": "floor",
-            "value": 1,
-            "field": "1ff9-3420-9c3a-91d2"
           }
         ],
         "constraints": [
-          {
-            "type": "max",
-            "value": 0,
-            "field": "selections",
-            "scope": "force",
-            "shared": true,
-            "id": "1ff9-3420-9c3a-91d2"
-          },
           {
             "comment": "Grand melee",
             "type": "max",
@@ -30646,6 +30283,13 @@
       {
         "categoryLinks": [
           {
+            "name": "Baron or Prophetess",
+            "hidden": false,
+            "id": "d1f5-fbb2-33ef-4fa6",
+            "targetId": "ed6d-58ea-c606-4b99",
+            "primary": false
+          },
+          {
             "name": "Characters",
             "hidden": false,
             "id": "2ffc-e47b-b216-6eb7",
@@ -31115,6 +30759,13 @@
       },
       {
         "categoryLinks": [
+          {
+            "name": "Baron or Prophetess",
+            "hidden": false,
+            "id": "f8f8-19ac-123b-4ba6",
+            "targetId": "ed6d-58ea-c606-4b99",
+            "primary": false
+          },
           {
             "name": "Characters",
             "hidden": false,
@@ -32059,6 +31710,168 @@
         "id": "27ef-9a5-83fe-d757",
         "targetId": "12a0-32cd-11d6-f952",
         "importRootEntries": true
+      }
+    ],
+    "categoryEntries": [
+      {
+        "constraints": [
+          {
+            "type": "max",
+            "value": 0,
+            "field": "selections",
+            "scope": "force",
+            "shared": true,
+            "id": "3619-1b5c-ffa5-4ab9",
+            "includeChildSelections": true
+          }
+        ],
+        "modifiers": [
+          {
+            "repeats": [
+              {
+                "value": 1000,
+                "repeats": 1,
+                "field": "limit::points",
+                "scope": "roster",
+                "childId": "any",
+                "shared": true,
+                "roundUp": false
+              }
+            ],
+            "conditionGroups": [
+              {
+                "conditions": [
+                  {
+                    "type": "instanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "8214-cf48-b1cd-5f5e",
+                    "shared": true
+                  },
+                  {
+                    "type": "instanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "1ae6-ed95-069e-a390",
+                    "shared": true
+                  },
+                  {
+                    "type": "instanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "cdbe-ecb9-27cb-fd2b",
+                    "shared": true
+                  },
+                  {
+                    "type": "instanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "0750-5d17-d708-f990",
+                    "shared": true
+                  },
+                  {
+                    "type": "instanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "e40a-36c4-0c66-472a",
+                    "shared": true
+                  }
+                ],
+                "type": "or"
+              }
+            ],
+            "type": "increment",
+            "value": 1,
+            "field": "3619-1b5c-ffa5-4ab9"
+          },
+          {
+            "repeats": [
+              {
+                "value": 1000,
+                "repeats": 1,
+                "field": "points",
+                "scope": "force",
+                "childId": "any",
+                "shared": true,
+                "roundUp": false
+              }
+            ],
+            "conditionGroups": [
+              {
+                "conditions": [
+                  {
+                    "type": "notInstanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "8214-cf48-b1cd-5f5e",
+                    "shared": true
+                  },
+                  {
+                    "type": "notInstanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "1ae6-ed95-069e-a390",
+                    "shared": true
+                  },
+                  {
+                    "type": "notInstanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "cdbe-ecb9-27cb-fd2b",
+                    "shared": true
+                  },
+                  {
+                    "type": "notInstanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "0750-5d17-d708-f990",
+                    "shared": true
+                  },
+                  {
+                    "type": "notInstanceOf",
+                    "value": 1,
+                    "field": "selections",
+                    "scope": "force",
+                    "childId": "e40a-36c4-0c66-472a",
+                    "shared": true
+                  }
+                ],
+                "type": "and"
+              }
+            ],
+            "type": "increment",
+            "value": 1,
+            "field": "3619-1b5c-ffa5-4ab9"
+          },
+          {
+            "comment": "Battle march",
+            "conditions": [
+              {
+                "type": "instanceOf",
+                "value": 1,
+                "field": "selections",
+                "scope": "ancestor",
+                "childId": "e40a-36c4-0c66-472a",
+                "shared": true
+              }
+            ],
+            "type": "floor",
+            "value": 1,
+            "field": "3619-1b5c-ffa5-4ab9"
+          }
+        ],
+        "name": "Baron or Prophetess",
+        "hidden": true,
+        "id": "ed6d-58ea-c606-4b99"
       }
     ],
     "sharedSelectionEntryGroups": [


### PR DESCRIPTION
all other factions I encountered used a category link that restrict the 0-1 per 1000 pts with an OR clause. For some reason, the Baron and the Prophetress did not. Instead they shared a pool.

Fixes #627