### PR TITLE
fix: Empire Greatswords have access to magical banner

### DIFF
--- a/The Empire of Man.json
+++ b/The Empire of Man.json
@@ -13297,27 +13297,9 @@
                         "id": "aee8-8e9f-19a6-f71"
                       }
                     ],
-                    "modifiers": [
-                      {
-                        "conditions": [
-                          {
-                            "type": "atLeast",
-                            "value": 1,
-                            "field": "selections",
-                            "scope": "499d-722a-5283-6ca5",
-                            "childId": "d316-b094-3046-4fb4",
-                            "shared": true,
-                            "includeChildSelections": true
-                          }
-                        ],
-                        "type": "set",
-                        "value": false,
-                        "field": "hidden"
-                      }
-                    ],
                     "import": true,
                     "name": "Magic Standards",
-                    "hidden": true,
+                    "hidden": false,
                     "type": "selectionEntryGroup",
                     "id": "dadf-68ef-12a5-fd94",
                     "targetId": "6bbe-8054-19b7-e5d6"


### PR DESCRIPTION
For some reason, the banners were hidden.

fixes #741